### PR TITLE
Fix has3d check preventing server use

### DIFF
--- a/lib/has3d.js
+++ b/lib/has3d.js
@@ -1,5 +1,5 @@
 module.exports = function has3d() {
-    if (!window.getComputedStyle) {
+    if (typeof window === 'undefined' || !window.getComputedStyle) {
         return false;
     }
 


### PR DESCRIPTION
The `has3d` module is called at require-time, but since it expects `window` to exist, it crashes when trying to render on the server side. This PR simply adds a check to ensure that we can still render it on the server.