### PR TITLE
Move DOM references to client lifecycle event

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -52,14 +52,6 @@ module.exports = React.createClass({
         }
     },
 
-    componentWillMount() {
-        // as the widths are calculated, we need to resize 
-        // the carousel when the window is resized
-        window.addEventListener("resize", this.updateSizes);
-        // issue #2 - image loading smaller
-        window.addEventListener("DOMContentLoaded", this.updateSizes);
-    },
-
     componentWillUnmount() {
         // removing listeners
         window.removeEventListener("resize", this.updateSizes);
@@ -67,7 +59,13 @@ module.exports = React.createClass({
     },
 
     componentDidMount (nextProps) {
-        // when the component is rendered we need to calculate 
+        // as the widths are calculated, we need to resize
+        // the carousel when the window is resized
+        window.addEventListener("resize", this.updateSizes);
+        // issue #2 - image loading smaller
+        window.addEventListener("DOMContentLoaded", this.updateSizes);
+
+        // when the component is rendered we need to calculate
         // the container size to adjust the responsive behaviour
         this.updateSizes();
 

--- a/src/components/Thumbs.js
+++ b/src/components/Thumbs.js
@@ -40,14 +40,6 @@ module.exports = React.createClass({
         }
     },
 
-    componentWillMount() {
-        // as the widths are calculated, we need to resize 
-        // the carousel when the window is resized
-        window.addEventListener("resize", this.updateStatics);
-        // issue #2 - image loading smaller
-        window.addEventListener("DOMContentLoaded", this.updateStatics);
-    },
-
     componentWillUnmount() {
         // removing listeners
         window.removeEventListener("resize", this.updateStatics);
@@ -55,7 +47,13 @@ module.exports = React.createClass({
     },
 
     componentDidMount (nextProps) {
-        // when the component is rendered we need to calculate 
+        // as the widths are calculated, we need to resize
+        // the carousel when the window is resized
+        window.addEventListener("resize", this.updateStatics);
+        // issue #2 - image loading smaller
+        window.addEventListener("DOMContentLoaded", this.updateStatics);
+
+        // when the component is rendered we need to calculate
         // the container size to adjust the responsive behaviour
         this.updateStatics();
 


### PR DESCRIPTION
ComponentWillMount runs in both the server and client and produces errors when you are trying to setup server rendering. ComponentDidMount only runs on the client so allows the components to be rendered on the server as well as the browser. 

[More in the React Docs](https://facebook.github.io/react/docs/component-specs.html#mounting-componentdidmount)

Possible TODO: Setup testing for isomorphic rendering.