### PR TITLE
Update Carousel.js

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -74,7 +74,7 @@ module.exports = React.createClass({
         this.isHorizontal = this.props.axis === 'horizontal';
         
         var defaultImg = ReactDOM.findDOMNode(this.item0).getElementsByTagName('img')[0];
-        defaultImg.addEventListener('load', this.setMountState);
+        defaultImg && defaultImg.addEventListener('load', this.setMountState);
     },
 
     updateSizes () {


### PR DESCRIPTION
Fix `Cannot read property 'addEventListener' of undefined` error when there's no images inside slides.