### PR TITLE
Fixes issue where carousel arrows would not be displayed

### DIFF
--- a/lib/components/Thumbs.js
+++ b/lib/components/Thumbs.js
@@ -48,6 +48,7 @@ module.exports = React.createClass({
         window.removeEventListener("DOMContentLoaded", this.updateStatics);
     },
     componentDidMount: function componentDidMount(nextProps) {
+        var that = this;
         // as the widths are calculated, we need to resize
         // the carousel when the window is resized
         window.addEventListener("resize", this.updateStatics);
@@ -55,7 +56,10 @@ module.exports = React.createClass({
         window.addEventListener("DOMContentLoaded", this.updateStatics);
 
         var defaultImg = ReactDOM.findDOMNode(this.thumb0).getElementsByTagName('img')[0];
-        defaultImg.addEventListener('load', this.setMountState);
+        defaultImg.addEventListener('load', function () {
+            that.setMountState();
+            that.updateStatics();
+        });
 
         // when the component is rendered we need to calculate
         // the container size to adjust the responsive behaviour

--- a/lib/components/Thumbs.js
+++ b/lib/components/Thumbs.js
@@ -48,7 +48,6 @@ module.exports = React.createClass({
         window.removeEventListener("DOMContentLoaded", this.updateStatics);
     },
     componentDidMount: function componentDidMount(nextProps) {
-        var that = this;
         // as the widths are calculated, we need to resize
         // the carousel when the window is resized
         window.addEventListener("resize", this.updateStatics);
@@ -56,10 +55,9 @@ module.exports = React.createClass({
         window.addEventListener("DOMContentLoaded", this.updateStatics);
 
         var defaultImg = ReactDOM.findDOMNode(this.thumb0).getElementsByTagName('img')[0];
-        defaultImg.addEventListener('load', function () {
-            that.setMountState();
-            that.updateStatics();
-        });
+        if(defaultImg) {
+            defaultImg.addEventListener('load', this.onFirstImageLoad);
+        }
 
         // when the component is rendered we need to calculate
         // the container size to adjust the responsive behaviour
@@ -73,8 +71,9 @@ module.exports = React.createClass({
         this.lastPosition = total - this.visibleItems;
         this.showArrows = this.visibleItems < total;
     },
-    setMountState: function setMountState() {
+    onFirstImageLoad: function onFirstImageLoad() {
         this.setState({ hasMount: true });
+        this.updateStatics();
     },
     handleClickItem: function handleClickItem(index, item) {
         var handler = this.props.onSelectItem;


### PR DESCRIPTION
Fixes #104. By getting the real image dimensions after load event, the carousel can calculate correctly if arrows should be visible or not.