### PR TITLE
#104 - Fixes problem where arrows were not appearing after carousel was loaded

### DIFF
--- a/src/components/Thumbs.js
+++ b/src/components/Thumbs.js
@@ -41,12 +41,6 @@ module.exports = React.createClass({
         }
     },
 
-    componentWillUnmount() {
-        // removing listeners
-        window.removeEventListener("resize", this.updateStatics);
-        window.removeEventListener("DOMContentLoaded", this.updateStatics);
-    },
-
     componentDidMount (nextProps) {
         // as the widths are calculated, we need to resize
         // the carousel when the window is resized
@@ -54,12 +48,25 @@ module.exports = React.createClass({
         // issue #2 - image loading smaller
         window.addEventListener("DOMContentLoaded", this.updateStatics);
 
-        var defaultImg = ReactDOM.findDOMNode(this.thumb0).getElementsByTagName('img')[0];
-        defaultImg.addEventListener('load', this.setMountState);
+        var defaultImg = this.getDefaultImage();
+        if (defaultImg) {
+            defaultImg.addEventListener('load', this.onFirstImageLoad);
+        }
 
         // when the component is rendered we need to calculate
         // the container size to adjust the responsive behaviour
         this.updateStatics();
+    },
+
+    componentWillUnmount() {
+        // removing listeners
+        window.removeEventListener("resize", this.updateStatics);
+        window.removeEventListener("DOMContentLoaded", this.updateStatics);
+
+        var defaultImg = this.getDefaultImage();
+        if (defaultImg) {
+            defaultImg.removeEventListener('load', this.onFirstImageLoad);
+        }
     },
 
     updateStatics () {
@@ -71,8 +78,20 @@ module.exports = React.createClass({
         this.showArrows = this.visibleItems < total;
     },
 
-    setMountState () {
+    getDefaultImage () {
+        var firstItem = ReactDOM.findDOMNode(this.thumb0);
+
+        if (firstItem) {
+            var firstImage = firstItem.getElementsByTagName('img');
+            return firstImage && firstImage[0];
+        }
+
+        return null;
+    },
+
+    onFirstImageLoad () {
         this.setState({hasMount: true});
+        this.updateStatics();
     },
 
     handleClickItem (index, item) {


### PR DESCRIPTION
This is a fix coming from the PR submited by @ttamminen.

Original PR: https://github.com/leandrowd/react-responsive-carousel/pull/105