### PR TITLE
Remove up and down keys

### DIFF
--- a/lib/components/Carousel.js
+++ b/lib/components/Carousel.js
@@ -88,8 +88,8 @@ var Carousel = function (_Component) {
         };
 
         _this.navigateWithKeyboard = function (e) {
-            var nextKeys = ['ArrowDown', 'ArrowRight'];
-            var prevKeys = ['ArrowUp', 'ArrowLeft'];
+            var nextKeys = ['ArrowRight'];
+            var prevKeys = ['ArrowLeft'];
             var allowedKeys = nextKeys.concat(prevKeys);
 
             if (allowedKeys.indexOf(e.key) > -1) {


### PR DESCRIPTION
My reasoning for this is because when using in production, let's say you have a site scrolls when you go up and down with arrow keys, normal users would like to move the site up and down, not the carousel. Removing them entirely is an easy solution, you can get fancy and add another boolean for up and down keys specifically. 👍 