### PR TITLE
added a clearTimeout() to autoPlay() to fix a warning

### DIFF
--- a/lib/components/Carousel.js
+++ b/lib/components/Carousel.js
@@ -69,6 +69,8 @@ var Carousel = function (_Component) {
                 return;
             }
 
+            clearTimeout(_this.timer);
+
             _this.timer = setTimeout(function () {
                 _this.increment();
             }, _this.props.interval);

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -186,6 +186,8 @@ class Carousel extends Component {
             return;
         }
 
+        clearTimeout(this.timer);
+
         this.timer = setTimeout(() => {
             this.increment();
         }, this.props.interval);


### PR DESCRIPTION
It seems like the timers being created in `autoPlay()` weren't being cleared for some reason... I have some suspicions but haven't been able to find the root cause. In the meantime, forcing a `clearTimeout()` before creating another `setTimer()` seems to fix the problem. See warning below:

```
Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the Carousel component.
```