### PR TITLE
Prevent affecting styling inside slide

### DIFF
--- a/src/components/_carousel.scss
+++ b/src/components/_carousel.scss
@@ -50,8 +50,6 @@
 
 	// only applying box sizing inside the plugin so it won't break any style
 	* {
-        margin: 0;
-        padding: 0;
 		-webkit-box-sizing: border-box;
 	  	-moz-box-sizing: border-box;
 	  	box-sizing: border-box;
@@ -176,6 +174,8 @@
 	}
 
 	.slider {
+		margin: 0;
+        padding: 0;
 		position: relative;
 		list-style: none;
 		width: 100%;
@@ -272,4 +272,3 @@
 		}
 	}
 }
-

--- a/src/components/_carousel.scss
+++ b/src/components/_carousel.scss
@@ -175,7 +175,7 @@
 
 	.slider {
 		margin: 0;
-        padding: 0;
+		padding: 0;
 		position: relative;
 		list-style: none;
 		width: 100%;


### PR DESCRIPTION
I have noticed that inside the slides of the carousel some styles get overridden by 'global' rules for everything nested inside the carousel (with the CSS * selector). This might not be a big deal when you only show images, but when you want to do other stuff inside the slide, it can be annoying.
I propose to change those 'global' style rules to only apply to the actual class names that it needs to apply to.