### PR TITLE
Remove thumb flickering, update images on change, and other fixes

### DIFF
--- a/lib/components/Carousel.js
+++ b/lib/components/Carousel.js
@@ -132,6 +132,10 @@ var Carousel = function (_Component) {
                 itemSize: itemSize,
                 wrapperSize: isHorizontal ? itemSize * _this.props.children.length : itemSize
             });
+
+            if (_this.refs.thumbs) {
+                _this.refs.thumbs.updateSizes();
+            }
         };
 
         _this.setMountState = function () {
@@ -517,7 +521,7 @@ var Carousel = function (_Component) {
 
             return _react2.default.createElement(
                 _Thumbs2.default,
-                { onSelectItem: this.handleClickThumb, selectedItem: this.state.selectedItem, transitionTime: this.props.transitionTime, thumbWidth: this.props.thumbWidth },
+                { ref: 'thumbs', onSelectItem: this.handleClickThumb, selectedItem: this.state.selectedItem, transitionTime: this.props.transitionTime, thumbWidth: this.props.thumbWidth },
                 this.props.children
             );
         }

--- a/lib/components/Thumbs.js
+++ b/lib/components/Thumbs.js
@@ -49,16 +49,23 @@ var Thumbs = function (_Component) {
         var _this = _possibleConstructorReturn(this, (Thumbs.__proto__ || Object.getPrototypeOf(Thumbs)).call(this, props));
 
         _this.updateSizes = function () {
-            if (!_this.state.initialized) {
+            if (!_this.props.children || !_this.refs.itemsWrapper) {
                 return;
             }
 
             var total = _this.props.children.length;
-            _this.wrapperSize = _this.itemsWrapper.clientWidth;
-            _this.itemSize = _this.props.thumbWidth ? _this.props.thumbWidth : (0, _dimensions.outerWidth)(_this.refs.thumb0);
-            _this.visibleItems = Math.floor(_this.wrapperSize / _this.itemSize);
-            _this.lastPosition = total - _this.visibleItems;
-            _this.showArrows = _this.visibleItems < total;
+            var wrapperSize = _this.refs.itemsWrapper.clientWidth;
+            var itemSize = _this.props.thumbWidth ? _this.props.thumbWidth : (0, _dimensions.outerWidth)(_this.refs.thumb0);
+            var visibleItems = Math.floor(wrapperSize / itemSize);
+            var lastPosition = total - visibleItems;
+            var showArrows = visibleItems < total;
+            _this.setState({
+                itemSize: itemSize,
+                visibleItems: visibleItems,
+                firstItem: showArrows ? _this.getFirstItem(_this.props.selectedItem) : 0,
+                lastPosition: lastPosition,
+                showArrows: showArrows
+            });
         };
 
         _this.setMountState = function () {
@@ -88,12 +95,9 @@ var Thumbs = function (_Component) {
 
         _this.onSwipeMove = function (deltaX) {
             var leftBoundry = 0;
-            var list = _reactDom2.default.findDOMNode(_this.itemList);
-            var wrapperSize = list.clientWidth;
-            var visibleItems = Math.floor(wrapperSize / _this.itemSize);
 
-            var currentPosition = -_this.state.firstItem * _this.itemSize;
-            var lastLeftBoundry = -_this.visibleItems * _this.itemSize;
+            var currentPosition = -_this.state.firstItem * _this.state.itemSize;
+            var lastLeftBoundry = -_this.state.visibleItems * _this.state.itemSize;
 
             // prevent user from swiping left out of boundaries
             if (currentPosition === leftBoundry && deltaX > 0) {
@@ -135,11 +139,14 @@ var Thumbs = function (_Component) {
         };
 
         _this.state = {
-            initialized: false,
             selectedItem: props.selectedItem,
             hasMount: false,
-            firstItem: _this.getFirstItem(props.selectedItem),
-            images: []
+            firstItem: 0,
+            itemSize: null,
+            visibleItems: 0,
+            lastPosition: 0,
+            showArrows: false,
+            images: _this.getImages()
         };
         return _this;
     }
@@ -147,10 +154,6 @@ var Thumbs = function (_Component) {
     _createClass(Thumbs, [{
         key: 'componentDidMount',
         value: function componentDidMount(nextProps) {
-            if (!this.props.children) {
-                return;
-            }
-
             this.setupThumbs();
         }
     }, {
@@ -162,13 +165,22 @@ var Thumbs = function (_Component) {
                     firstItem: this.getFirstItem(props.selectedItem)
                 });
             }
+            if (props.children !== this.props.children) {
+                this.setState({
+                    images: this.getImages()
+                });
+            }
         }
     }, {
         key: 'componentDidUpdate',
         value: function componentDidUpdate(prevProps) {
-            if (!prevProps.children && this.props.children && !this.state.initialized) {
-                this.setupThumbs();
+            if (this.props.children === prevProps.children) {
+                return;
             }
+
+            // This will capture any size changes for arrow adjustments etc.
+            // usually in the same render cycle so we don't see any flickers
+            this.updateSizes();
         }
     }, {
         key: 'componentWillUnmount',
@@ -183,17 +195,6 @@ var Thumbs = function (_Component) {
             window.addEventListener("resize", this.updateSizes);
             // issue #2 - image loading smaller
             window.addEventListener("DOMContentLoaded", this.updateSizes);
-
-            var images = this.getImages();
-
-            if (!images) {
-                return;
-            }
-
-            this.setState({
-                initialized: true,
-                images: images
-            });
 
             // when the component is rendered we need to calculate
             // the container size to adjust the responsive behaviour
@@ -239,17 +240,13 @@ var Thumbs = function (_Component) {
     }, {
         key: 'getFirstItem',
         value: function getFirstItem(selectedItem) {
-            if (!this.showArrows) {
-                return 0;
-            }
-
             var firstItem = selectedItem;
 
-            if (selectedItem >= this.lastPosition) {
-                firstItem = this.lastPosition;
+            if (selectedItem >= this.state.lastPosition) {
+                firstItem = this.state.lastPosition;
             }
 
-            if (selectedItem < this.state.firstItem + this.visibleItems) {
+            if (selectedItem < this.state.firstItem + this.state.visibleItems) {
                 firstItem = this.state.firstItem;
             }
 
@@ -292,18 +289,18 @@ var Thumbs = function (_Component) {
         value: function render() {
             var _this3 = this;
 
-            if (!this.props.children || this.state.images.length === 0) {
+            if (!this.props.children) {
                 return null;
             }
 
             // show left arrow?
-            var hasPrev = this.showArrows && this.state.firstItem > 0;
+            var hasPrev = this.state.showArrows && this.state.firstItem > 0;
             // show right arrow
-            var hasNext = this.showArrows && this.state.firstItem < this.lastPosition;
+            var hasNext = this.state.showArrows && this.state.firstItem < this.state.lastPosition;
             // obj to hold the transformations and styles
             var itemListStyles = {};
 
-            var currentPosition = -this.state.firstItem * this.itemSize + 'px';
+            var currentPosition = -this.state.firstItem * this.state.itemSize + 'px';
 
             var transformProp = (0, _CSSTranslate2.default)(currentPosition, this.props.axis);
 
@@ -329,9 +326,7 @@ var Thumbs = function (_Component) {
                 { className: _cssClasses2.default.CAROUSEL(false) },
                 _react2.default.createElement(
                     'div',
-                    { className: _cssClasses2.default.WRAPPER(false), ref: function ref(node) {
-                            return _this3.itemsWrapper = node;
-                        } },
+                    { className: _cssClasses2.default.WRAPPER(false), ref: 'itemsWrapper' },
                     _react2.default.createElement('button', { type: 'button', className: _cssClasses2.default.ARROW_PREV(!hasPrev), onClick: this.slideRight }),
                     _react2.default.createElement(
                         _reactEasySwipe2.default,

--- a/src/__tests__/__snapshots__/Carousel.js.snap
+++ b/src/__tests__/__snapshots__/Carousel.js.snap
@@ -204,17 +204,17 @@ exports[`Slider Snapshots center mode 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "MozTransform": "translate3d(NaNpx,0,0)",
+            "MozTransform": "translate3d(0px,0,0)",
             "MozTransitionDuration": "350ms",
-            "MsTransform": "translate3d(NaNpx,0,0)",
+            "MsTransform": "translate3d(0px,0,0)",
             "MsTransitionDuration": "350ms",
-            "OTransform": "translate3d(NaNpx,0,0)",
+            "OTransform": "translate3d(0px,0,0)",
             "OTransitionDuration": "350ms",
-            "WebkitTransform": "translate3d(NaNpx,0,0)",
+            "WebkitTransform": "translate3d(0px,0,0)",
             "WebkitTransitionDuration": "350ms",
-            "msTransform": "translate3d(NaNpx,0,0)",
+            "msTransform": "translate3d(0px,0,0)",
             "msTransitionDuration": "350ms",
-            "transform": "translate3d(NaNpx,0,0)",
+            "transform": "translate3d(0px,0,0)",
             "transitionDuration": "350ms",
           }
         }
@@ -456,17 +456,17 @@ exports[`Slider Snapshots custom class name 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "MozTransform": "translate3d(NaNpx,0,0)",
+            "MozTransform": "translate3d(0px,0,0)",
             "MozTransitionDuration": "350ms",
-            "MsTransform": "translate3d(NaNpx,0,0)",
+            "MsTransform": "translate3d(0px,0,0)",
             "MsTransitionDuration": "350ms",
-            "OTransform": "translate3d(NaNpx,0,0)",
+            "OTransform": "translate3d(0px,0,0)",
             "OTransitionDuration": "350ms",
-            "WebkitTransform": "translate3d(NaNpx,0,0)",
+            "WebkitTransform": "translate3d(0px,0,0)",
             "WebkitTransitionDuration": "350ms",
-            "msTransform": "translate3d(NaNpx,0,0)",
+            "msTransform": "translate3d(0px,0,0)",
             "msTransitionDuration": "350ms",
-            "transform": "translate3d(NaNpx,0,0)",
+            "transform": "translate3d(0px,0,0)",
             "transitionDuration": "350ms",
           }
         }
@@ -708,17 +708,17 @@ exports[`Slider Snapshots custom width 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "MozTransform": "translate3d(NaNpx,0,0)",
+            "MozTransform": "translate3d(0px,0,0)",
             "MozTransitionDuration": "350ms",
-            "MsTransform": "translate3d(NaNpx,0,0)",
+            "MsTransform": "translate3d(0px,0,0)",
             "MsTransitionDuration": "350ms",
-            "OTransform": "translate3d(NaNpx,0,0)",
+            "OTransform": "translate3d(0px,0,0)",
             "OTransitionDuration": "350ms",
-            "WebkitTransform": "translate3d(NaNpx,0,0)",
+            "WebkitTransform": "translate3d(0px,0,0)",
             "WebkitTransitionDuration": "350ms",
-            "msTransform": "translate3d(NaNpx,0,0)",
+            "msTransform": "translate3d(0px,0,0)",
             "msTransitionDuration": "350ms",
-            "transform": "translate3d(NaNpx,0,0)",
+            "transform": "translate3d(0px,0,0)",
             "transitionDuration": "350ms",
           }
         }
@@ -960,17 +960,17 @@ exports[`Slider Snapshots default 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "MozTransform": "translate3d(NaNpx,0,0)",
+            "MozTransform": "translate3d(0px,0,0)",
             "MozTransitionDuration": "350ms",
-            "MsTransform": "translate3d(NaNpx,0,0)",
+            "MsTransform": "translate3d(0px,0,0)",
             "MsTransitionDuration": "350ms",
-            "OTransform": "translate3d(NaNpx,0,0)",
+            "OTransform": "translate3d(0px,0,0)",
             "OTransitionDuration": "350ms",
-            "WebkitTransform": "translate3d(NaNpx,0,0)",
+            "WebkitTransform": "translate3d(0px,0,0)",
             "WebkitTransitionDuration": "350ms",
-            "msTransform": "translate3d(NaNpx,0,0)",
+            "msTransform": "translate3d(0px,0,0)",
             "msTransitionDuration": "350ms",
-            "transform": "translate3d(NaNpx,0,0)",
+            "transform": "translate3d(0px,0,0)",
             "transitionDuration": "350ms",
           }
         }
@@ -1212,17 +1212,17 @@ exports[`Slider Snapshots no arrows 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "MozTransform": "translate3d(NaNpx,0,0)",
+            "MozTransform": "translate3d(0px,0,0)",
             "MozTransitionDuration": "350ms",
-            "MsTransform": "translate3d(NaNpx,0,0)",
+            "MsTransform": "translate3d(0px,0,0)",
             "MsTransitionDuration": "350ms",
-            "OTransform": "translate3d(NaNpx,0,0)",
+            "OTransform": "translate3d(0px,0,0)",
             "OTransitionDuration": "350ms",
-            "WebkitTransform": "translate3d(NaNpx,0,0)",
+            "WebkitTransform": "translate3d(0px,0,0)",
             "WebkitTransitionDuration": "350ms",
-            "msTransform": "translate3d(NaNpx,0,0)",
+            "msTransform": "translate3d(0px,0,0)",
             "msTransitionDuration": "350ms",
-            "transform": "translate3d(NaNpx,0,0)",
+            "transform": "translate3d(0px,0,0)",
             "transitionDuration": "350ms",
           }
         }
@@ -1427,17 +1427,17 @@ exports[`Slider Snapshots no indicators 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "MozTransform": "translate3d(NaNpx,0,0)",
+            "MozTransform": "translate3d(0px,0,0)",
             "MozTransitionDuration": "350ms",
-            "MsTransform": "translate3d(NaNpx,0,0)",
+            "MsTransform": "translate3d(0px,0,0)",
             "MsTransitionDuration": "350ms",
-            "OTransform": "translate3d(NaNpx,0,0)",
+            "OTransform": "translate3d(0px,0,0)",
             "OTransitionDuration": "350ms",
-            "WebkitTransform": "translate3d(NaNpx,0,0)",
+            "WebkitTransform": "translate3d(0px,0,0)",
             "WebkitTransitionDuration": "350ms",
-            "msTransform": "translate3d(NaNpx,0,0)",
+            "msTransform": "translate3d(0px,0,0)",
             "msTransitionDuration": "350ms",
-            "transform": "translate3d(NaNpx,0,0)",
+            "transform": "translate3d(0px,0,0)",
             "transitionDuration": "350ms",
           }
         }
@@ -1674,17 +1674,17 @@ exports[`Slider Snapshots no indicators 2`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "MozTransform": "translate3d(NaNpx,0,0)",
+            "MozTransform": "translate3d(0px,0,0)",
             "MozTransitionDuration": "350ms",
-            "MsTransform": "translate3d(NaNpx,0,0)",
+            "MsTransform": "translate3d(0px,0,0)",
             "MsTransitionDuration": "350ms",
-            "OTransform": "translate3d(NaNpx,0,0)",
+            "OTransform": "translate3d(0px,0,0)",
             "OTransitionDuration": "350ms",
-            "WebkitTransform": "translate3d(NaNpx,0,0)",
+            "WebkitTransform": "translate3d(0px,0,0)",
             "WebkitTransitionDuration": "350ms",
-            "msTransform": "translate3d(NaNpx,0,0)",
+            "msTransform": "translate3d(0px,0,0)",
             "msTransitionDuration": "350ms",
-            "transform": "translate3d(NaNpx,0,0)",
+            "transform": "translate3d(0px,0,0)",
             "transitionDuration": "350ms",
           }
         }
@@ -2077,17 +2077,17 @@ exports[`Slider Snapshots swipeable false 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "MozTransform": "translate3d(NaNpx,0,0)",
+            "MozTransform": "translate3d(0px,0,0)",
             "MozTransitionDuration": "350ms",
-            "MsTransform": "translate3d(NaNpx,0,0)",
+            "MsTransform": "translate3d(0px,0,0)",
             "MsTransitionDuration": "350ms",
-            "OTransform": "translate3d(NaNpx,0,0)",
+            "OTransform": "translate3d(0px,0,0)",
             "OTransitionDuration": "350ms",
-            "WebkitTransform": "translate3d(NaNpx,0,0)",
+            "WebkitTransform": "translate3d(0px,0,0)",
             "WebkitTransitionDuration": "350ms",
-            "msTransform": "translate3d(NaNpx,0,0)",
+            "msTransform": "translate3d(0px,0,0)",
             "msTransitionDuration": "350ms",
-            "transform": "translate3d(NaNpx,0,0)",
+            "transform": "translate3d(0px,0,0)",
             "transitionDuration": "350ms",
           }
         }
@@ -2334,17 +2334,17 @@ exports[`Slider Snapshots vertical axis 1`] = `
         onTouchStart={[Function]}
         style={
           Object {
-            "MozTransform": "translate3d(NaNpx,0,0)",
+            "MozTransform": "translate3d(0px,0,0)",
             "MozTransitionDuration": "350ms",
-            "MsTransform": "translate3d(NaNpx,0,0)",
+            "MsTransform": "translate3d(0px,0,0)",
             "MsTransitionDuration": "350ms",
-            "OTransform": "translate3d(NaNpx,0,0)",
+            "OTransform": "translate3d(0px,0,0)",
             "OTransitionDuration": "350ms",
-            "WebkitTransform": "translate3d(NaNpx,0,0)",
+            "WebkitTransform": "translate3d(0px,0,0)",
             "WebkitTransitionDuration": "350ms",
-            "msTransform": "translate3d(NaNpx,0,0)",
+            "msTransform": "translate3d(0px,0,0)",
             "msTransitionDuration": "350ms",
-            "transform": "translate3d(NaNpx,0,0)",
+            "transform": "translate3d(0px,0,0)",
             "transitionDuration": "350ms",
           }
         }

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -256,6 +256,10 @@ class Carousel extends Component {
             itemSize: itemSize,
             wrapperSize: isHorizontal ? itemSize * this.props.children.length : itemSize
         });
+
+        if (this.refs.thumbs) {
+            this.refs.thumbs.updateSizes();
+        }
     }
 
     setMountState = () => {
@@ -507,7 +511,7 @@ class Carousel extends Component {
         }
 
         return (
-            <Thumbs onSelectItem={this.handleClickThumb} selectedItem={this.state.selectedItem} transitionTime={this.props.transitionTime} thumbWidth={this.props.thumbWidth}>
+            <Thumbs ref="thumbs" onSelectItem={this.handleClickThumb} selectedItem={this.state.selectedItem} transitionTime={this.props.transitionTime} thumbWidth={this.props.thumbWidth}>
                 {this.props.children}
             </Thumbs>
         );


### PR DESCRIPTION
Hello!

This is a fairly big PR for which I apologise. To get it to work and clean I had to refactor thumbs a little.
Below are issues addressed in this PR and any relevant issue numbers:

1. Fix #226 Resizing window can make Thumbs enter incorrect state
    * updateSizes/getFirstItem combination now ensures that when we go from small width to big width, we update firstItem to be 0 so all thumbs display, whereas previously it would stay at say, 2, and mean there's two missing thumbnails and no arrows to access them
2. Similar to #226 but discovered after the initial fix. When moving from big to small width, the selected item could disappear behind the arrows.
    * updateSizes/getFirstItem combination now ensures selected item is always visible during resizes
3. Flickering of arrows whenever the carousel images are updated
    * updateSizes now uses setState so that it triggers a render exactly when things change. Before there was no setState so it was actually waiting for the carousel itself to cause a render and in my case made a flicker, presumedly because that render happened in a separate cycle.
4. Fix #213 Thumbnails not updating when images are updated.
    * Now we check children change on every prop update and update images state accordingly and visibility of items
5. There was no way to trigger a resize of thumbs to make arrows appear and disappear if the carousel changed size without the window resizing (we have it in a flex area so it flexes with other items)
    * Carousel updateSizes API now calls the same on the Thumbs component, so we can just call updateSizes on carousel now and everything updates cleanly.
6. Due to above changes, tests were failing due to clientWidth undefined on itemsWrapper. Seems tests did not test the updateSizes correctly due to no real DOM, but now that it's called within the rendering cycle it now picks it up
    * Simply check for itemsWrapper before allowing updateSizes, since it will calls it again anyway on any update to props after a render. This fixes tests.
    * This will likely also fix #162 server rendering though I am unable to confirm or guarantee there won't be further issues

Happy to consider tests but I'm completely alien to the type of tests happening or what kind of things best to test. Or would you say the existing tests cover most things already (since this is all minor fixes really)? I guess maybe a test for the firstItem stuff and the updateSizes call?

Thanks and hope this saves you some time :smile: