### PR TITLE
Fix dynamicHeight initialization

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -454,13 +454,13 @@ class Carousel extends Component {
 
     getInitialImage = () => {
         const selectedItem = this.props.selectedItem;
-        const item = this.itemsRef[selectedItem];
+        const item = this.itemsRef && this.itemsRef[selectedItem];
         const images = item && item.getElementsByTagName('img');
         return images && images[selectedItem];
     }
 
     getVariableImageHeight = (position) => {
-        const item = this.itemsRef[position];
+        const item = this.itemsRef && this.itemsRef[position];
         const images = item && item.getElementsByTagName('img');
         if (this.state.hasMount && images.length > 0) {
             const image = images[0];


### PR DESCRIPTION
Added a couple defensive checks to prevent the error that occurs when `getVariableImageHeight` is called prior to `itemsRef` being initialized, which currently happens when the dynamicHeight option is enabled. There's discussion of another solution in #237, but this gets the job done and probably isn't a bad check to have anyway.

Made sure that the relevant story is fixed: http://localhost:9001/?selectedKind=Carousel&selectedStory=dynamic%20height%20images&full=0&down=1&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel