### PR TITLE
Fix wrapperSize ref

### DIFF
--- a/src/components/Thumbs.js
+++ b/src/components/Thumbs.js
@@ -173,21 +173,22 @@ class Thumbs extends Component {
     }
 
     onSwipeMove = (deltaX) => {
-        const leftBoundry = 0;
+        const leftBoundary = 0;
 
         const currentPosition = - this.state.firstItem * this.state.itemSize;
-        const lastLeftBoundry = - this.state.visibleItems * this.state.itemSize;
+        const lastLeftBoundary = - this.state.visibleItems * this.state.itemSize;
 
         // prevent user from swiping left out of boundaries
-        if (currentPosition === leftBoundry && deltaX > 0) {
+        if (currentPosition === leftBoundary && deltaX > 0) {
             deltaX = 0;
         }
 
         // prevent user from swiping right out of boundaries
-        if (currentPosition === lastLeftBoundry && deltaX < 0) {
+        if (currentPosition === lastLeftBoundary && deltaX < 0) {
             deltaX = 0;
         }
 
+        const wrapperSize = this.itemsWrapperRef.clientWidth;
         const position = currentPosition + (100 / (wrapperSize / deltaX)) + '%';
 
         // if 3d isn't available we will use left to move


### PR DESCRIPTION
It appears a `wrapperSize` variable was inadvertently removed, so the `Thumbs.onSwipeMove` function currently throws an exception each time it is called.

This PR fixes the variable definition & fixes a typo in the word "boundary."