### PR TITLE
Restore resetPosition but place on componentDidUpdate

### DIFF
--- a/lib/components/Carousel.js
+++ b/lib/components/Carousel.js
@@ -262,6 +262,11 @@ var Carousel = function (_Component) {
             });
         };
 
+        _this.resetPosition = function () {
+            var currentPosition = _this.getPosition(_this.state.selectedItem) + '%';
+            _this.setPosition(currentPosition);
+        };
+
         _this.decrement = function (positions) {
             _this.moveTo(_this.state.selectedItem - (typeof positions === 'Number' ? positions : 1));
         };
@@ -379,9 +384,13 @@ var Carousel = function (_Component) {
         }
     }, {
         key: 'componentDidUpdate',
-        value: function componentDidUpdate(prevProps) {
+        value: function componentDidUpdate(prevProps, prevState) {
             if (!prevProps.children && this.props.children && !this.state.initialized) {
                 this.setupCarousel();
+            }
+            if (prevState.swiping && !this.state.swiping) {
+                // We stopped swiping, ensure we are heading to the new/current slide and not stuck
+                this.resetPosition();
             }
         }
     }, {

--- a/src/__tests__/Carousel.js
+++ b/src/__tests__/Carousel.js
@@ -138,6 +138,15 @@ describe("Slider", function() {
         });
     });
 
+    describe("componentDidUpdate", () => {
+        it("should unbind the events", () => {
+            componentInstance.resetPosition = jest.genMockFunction();
+            componentInstance.setState({swiping: false});
+            componentInstance.componentDidUpdate({}, {swiping: true});
+            expect(componentInstance.resetPosition.mock.calls.length).toBe(1);
+        });
+    });
+
     describe("componentWillUnmount", () => {
         beforeEach(() => {
             componentInstance.unbindEvents = jest.genMockFunction();

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -110,9 +110,13 @@ class Carousel extends Component {
         }
     }
 
-    componentDidUpdate(prevProps) {
+    componentDidUpdate(prevProps, prevState) {
         if (!prevProps.children && this.props.children && !this.state.initialized) {
             this.setupCarousel();
+        }
+        if (prevState.swiping && !this.state.swiping) {
+            // We stopped swiping, ensure we are heading to the new/current slide and not stuck
+            this.resetPosition();
         }
     }
 
@@ -413,6 +417,11 @@ class Carousel extends Component {
         ].forEach((prop) => {
             list.style[prop] = CSSTranslate(position, this.props.axis);
         });
+    }
+
+    resetPosition = () => {
+        const currentPosition = this.getPosition(this.state.selectedItem) + '%';
+        this.setPosition(currentPosition);
     }
 
     decrement = (positions) => {


### PR DESCRIPTION
This ensures we reset position to the NEW slide in the case where a change just occurred. And also ensures when threshold for swipe was not met, we are still resetting and not leaving a slide mid-swipe.

Related to regression in PR #249 and the original issue #154