### PR TITLE
Accesible prev next buttons

### DIFF
--- a/src/__tests__/__snapshots__/Carousel.js.snap
+++ b/src/__tests__/__snapshots__/Carousel.js.snap
@@ -16,7 +16,13 @@ exports[`Slider Snapshots center mode 1`] = `
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Previous slide
+      </span>
+    </button>
     <div
       className="slider-wrapper axis-horizontal"
       style={Object {}}
@@ -140,7 +146,13 @@ exports[`Slider Snapshots center mode 1`] = `
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Next slide
+      </span>
+    </button>
     <ul
       className="control-dots"
     >
@@ -303,7 +315,13 @@ exports[`Slider Snapshots custom class name 1`] = `
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Previous slide
+      </span>
+    </button>
     <div
       className="slider-wrapper axis-horizontal"
       style={Object {}}
@@ -392,7 +410,13 @@ exports[`Slider Snapshots custom class name 1`] = `
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Next slide
+      </span>
+    </button>
     <ul
       className="control-dots"
     >
@@ -555,7 +579,13 @@ exports[`Slider Snapshots custom width 1`] = `
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Previous slide
+      </span>
+    </button>
     <div
       className="slider-wrapper axis-horizontal"
       style={Object {}}
@@ -644,7 +674,13 @@ exports[`Slider Snapshots custom width 1`] = `
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Next slide
+      </span>
+    </button>
     <ul
       className="control-dots"
     >
@@ -807,7 +843,13 @@ exports[`Slider Snapshots default 1`] = `
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Previous slide
+      </span>
+    </button>
     <div
       className="slider-wrapper axis-horizontal"
       style={Object {}}
@@ -896,7 +938,13 @@ exports[`Slider Snapshots default 1`] = `
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Next slide
+      </span>
+    </button>
     <ul
       className="control-dots"
     >
@@ -1059,7 +1107,13 @@ exports[`Slider Snapshots no arrows 1`] = `
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Previous slide
+      </span>
+    </button>
     <div
       className="slider-wrapper axis-horizontal"
       style={Object {}}
@@ -1148,7 +1202,13 @@ exports[`Slider Snapshots no arrows 1`] = `
       className="control-arrow control-next control-disabled"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Next slide
+      </span>
+    </button>
     <ul
       className="control-dots"
     >
@@ -1313,7 +1373,13 @@ exports[`Slider Snapshots no indicators 1`] = `
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Previous slide
+      </span>
+    </button>
     <div
       className="slider-wrapper axis-horizontal"
       style={Object {}}
@@ -1402,7 +1468,13 @@ exports[`Slider Snapshots no indicators 1`] = `
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Next slide
+      </span>
+    </button>
     <p
       className="carousel-status"
     >
@@ -1526,7 +1598,13 @@ exports[`Slider Snapshots no indicators 2`] = `
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Previous slide
+      </span>
+    </button>
     <div
       className="slider-wrapper axis-horizontal"
       style={Object {}}
@@ -1615,7 +1693,13 @@ exports[`Slider Snapshots no indicators 2`] = `
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Next slide
+      </span>
+    </button>
     <ul
       className="control-dots"
     >
@@ -1773,7 +1857,13 @@ exports[`Slider Snapshots no thumbs 1`] = `
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Previous slide
+      </span>
+    </button>
     <div
       className="slider-wrapper axis-horizontal"
       style={Object {}}
@@ -1862,7 +1952,13 @@ exports[`Slider Snapshots no thumbs 1`] = `
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Next slide
+      </span>
+    </button>
     <ul
       className="control-dots"
     >
@@ -1927,7 +2023,13 @@ exports[`Slider Snapshots swipeable false 1`] = `
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Previous slide
+      </span>
+    </button>
     <div
       className="slider-wrapper axis-horizontal"
       style={Object {}}
@@ -2013,7 +2115,13 @@ exports[`Slider Snapshots swipeable false 1`] = `
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Next slide
+      </span>
+    </button>
     <ul
       className="control-dots"
     >
@@ -2176,7 +2284,13 @@ exports[`Slider Snapshots vertical axis 1`] = `
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Previous slide
+      </span>
+    </button>
     <div
       className="slider-wrapper axis-vertical"
       style={
@@ -2270,7 +2384,13 @@ exports[`Slider Snapshots vertical axis 1`] = `
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
-    />
+    >
+      <span
+        className="hidden"
+      >
+        Next slide
+      </span>
+    </button>
     <ul
       className="control-dots"
     >

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -633,7 +633,9 @@ class Carousel extends Component {
         return (
             <div className={this.props.className} ref={this.setCarouselWrapperRef}>
                 <div className={klass.CAROUSEL(true)} style={{width: this.props.width}}>
-                    <button type="button" className={klass.ARROW_PREV(!hasPrev)} onClick={this.decrement} />
+                    <button type="button" className={klass.ARROW_PREV(!hasPrev)} onClick={this.decrement} >
+                        <span className="hidden">Previous slide</span>
+                    </button>
                     <div className={klass.WRAPPER(true, this.props.axis)} style={containerStyles} ref={this.setItemsWrapperRef}>
                         { this.props.swipeable ?
                             <Swipe
@@ -650,7 +652,9 @@ class Carousel extends Component {
                             </ul>
                         }
                     </div>
-                    <button type="button" className={klass.ARROW_NEXT(!hasNext)} onClick={this.increment} />
+                    <button type="button" className={klass.ARROW_NEXT(!hasNext)} onClick={this.increment} >
+                        <span className="hidden">Next slide</span>
+                    </button>
 
                     { this.renderControls() }
                     { this.renderStatus() }

--- a/src/main.scss
+++ b/src/main.scss
@@ -136,3 +136,12 @@ code {
 h5 {
 	margin-bottom: 10px;
 }
+
+.hidden {
+    position:absolute;
+    left:-10000px;
+    top:auto;
+    width:1px;
+    height:1px;
+    overflow:hidden;
+}


### PR DESCRIPTION
I created this PR because we are using this component and it doesn't meet the appropriate accessibility standards using [WAVE](http://wave.webaim.org/extension/) tool.

I saw another PR that will let the component render custom arrow buttons and indicators, but this is temporarily thing while we wait for the PR to be merged. 

I added the `.hidden` class suggested in [Invisible Content Just for Screen Reader Users](https://webaim.org/techniques/css/invisiblecontent/).

Let me know if there is something else I have to change.