### PR TITLE
Fixes #283 - control-dots on top of youtube controls

### DIFF
--- a/src/components/_carousel.scss
+++ b/src/components/_carousel.scss
@@ -229,7 +229,9 @@
 		bottom: 0;
 		margin: 10px 0;
 		text-align: center;
-		width: 100%;
+		width: auto;
+		left: 50%;
+		transform: translate(-50%, 0);
 
 		@include desktop {
 			bottom: 0;


### PR DESCRIPTION
This is a proposition to fix issue #283 by making the control-dots not 100% in width, but auto and centered along the x-axis.