### PR TITLE
Handle undefined item list ref

### DIFF
--- a/src/components/Thumbs.js
+++ b/src/components/Thumbs.js
@@ -192,16 +192,18 @@ class Thumbs extends Component {
         const position = currentPosition + (100 / (wrapperSize / deltaX)) + '%';
 
         // if 3d isn't available we will use left to move
-        [
-            'WebkitTransform',
-            'MozTransform',
-            'MsTransform',
-            'OTransform',
-            'transform',
-            'msTransform'
-        ].forEach((prop) => {
-            this.itemsListRef.style[prop] = CSSTranslate(position, this.props.axis);
-        });
+        if (this.itemsListRef) {
+            [
+                'WebkitTransform',
+                'MozTransform',
+                'MsTransform',
+                'OTransform',
+                'transform',
+                'msTransform'
+            ].forEach((prop) => {
+                this.itemsListRef.style[prop] = CSSTranslate(position, this.props.axis);
+            });
+        }
     }
 
     slideRight = (positions) => {


### PR DESCRIPTION
Currently `onSwipeMove` can sometimes be called before the itemsListRef is initialized, causing an "undefined is not an object" error when its style property is attempted to be set. This PR fixes the issue by simply checking that the ref exists before accessing it.