### PR TITLE
Classify /lib as generated code for LGTM

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,3 @@
+path_classifiers:
+  generated:
+    - "/lib"


### PR DESCRIPTION
Following #287, #291 and #292, the only LGTM.com alerts remaining are going to be some recommendations in `/lib`. This code is generated (if i understand correctly), and so it doesn't make sense to display alerts that are found here.

This PR introduces a configuration file that will tell LGTM to suppress these alerts, after this and the other PRs are merged, the alert count will probably be 0. :smile: 