### PR TITLE
Update links to online demos and CodeSandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Powerful, lightweight and fully customizable carousel component for React apps.
 ### Demo
 <http://leandrowd.github.io/react-responsive-carousel/>
 
-Check it out these [cool demos](http://react-responsive-carousel.js.org/storybook/index.html) created using [storybook](https://getstorybook.io/). The source code for each example is available [here](https://github.com/leandrowd/react-responsive-carousel/blob/master/stories/index.js)
+Check it out these [cool demos](http://react-responsive-carousel.js.org/#demos) created using [storybook](https://getstorybook.io/). The source code for each example is available [here](https://github.com/leandrowd/react-responsive-carousel/blob/master/stories/index.js)
 
 Customize it yourself:
 - Codesandbox: <https://codesandbox.io/s/7jql2v8zwq>
@@ -161,7 +161,7 @@ When raising an issue, please add as much details as possible. Screenshots, vide
 <https://github.com/leandrowd/demo-react-responsive-carousel-es6>
 
 #### Storybook
-<http://react-responsive-carousel.js.org/storybook/>
+<http://react-responsive-carousel.js.org/#demos>
 
 #### Codesandbox
 <https://codesandbox.io/s/lp602ljjj7>

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Powerful, lightweight and fully customizable carousel component for React apps.
 ### Important links:
 - [Before contributing](https://github.com/leandrowd/react-responsive-carousel/blob/master/CONTRIBUTING.md)
 - [Customizable example](https://codesandbox.io/s/lp602ljjj7)
-- [Demos](http://react-responsive-carousel.js.org/storybook/)
+- [Demos](http://react-responsive-carousel.js.org/#demos)
 - [Changelog](https://github.com/leandrowd/react-responsive-carousel/blob/master/CHANGELOG.md)
 - [Troubleshooting](https://github.com/leandrowd/react-responsive-carousel/blob/master/TROUBLESHOOTING.md)
 
@@ -41,7 +41,7 @@ Powerful, lightweight and fully customizable carousel component for React apps.
 Check it out these [cool demos](http://react-responsive-carousel.js.org/storybook/index.html) created using [storybook](https://getstorybook.io/). The source code for each example is available [here](https://github.com/leandrowd/react-responsive-carousel/blob/master/stories/index.js)
 
 Customize it yourself:
-- Codesandbox: <https://codesandbox.io/s/lp602ljjj7>
+- Codesandbox: <https://codesandbox.io/s/7jql2v8zwq>
 
 ### Installing as a package
 `npm install react-responsive-carousel --save`


### PR DESCRIPTION
This addresses the broken demo hyperlinks in the README. See this issue: https://github.com/leandrowd/react-responsive-carousel/issues/300

I also created a new CodeSandbox (forked it from the one that was previously referenced in the README) to use the new version of the npm package (3.2.45). @leandrowd If you prefer to continue to use your CodeSandbox and want to just update that package, I can undo the change to that link in the README.

Cheers
R