### PR TITLE
Issue #256: onItemClick doesn't work when you only have 1 item

### DIFF
--- a/src/__tests__/Carousel.js
+++ b/src/__tests__/Carousel.js
@@ -416,9 +416,12 @@ describe("Slider", function() {
 
             component.findWhere(n => n.node === componentInstance.itemsRef[1]).simulate('click');
 			expect(mockedFunction).toBeCalled();
+
+            component.findWhere(n => n.node === componentInstance.itemsRef[0]).simulate('click');
+            expect(componentInstance.state.selectedItem).toBe(0);
         });
 
-        it('should be disabled when only 1 child is present', () => {
+        it('should call onSelectItem function when exactly 1 child is present', () => {
             var mockedFunction = jest.genMockFunction();
 
             renderDefaultComponent({
@@ -429,7 +432,7 @@ describe("Slider", function() {
 
             component.findWhere(n => n.node === componentInstance.itemsRef[0]).simulate('click');
             expect(componentInstance.state.selectedItem).toBe(0);
-			expect(mockedFunction).not.toBeCalled();
+			expect(mockedFunction).toBeCalled();
 		});
 	})
 

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -300,7 +300,7 @@ class Carousel extends Component {
     }
 
     handleClickItem = (index, item) => {
-        if (Children.count(this.props.children) <= 0) {
+        if (Children.count(this.props.children) == 0) {
             return;
         }
 

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -300,7 +300,7 @@ class Carousel extends Component {
     }
 
     handleClickItem = (index, item) => {
-        if (Children.count(this.props.children) <= 1) {
+        if (Children.count(this.props.children) <= 0) {
             return;
         }
 


### PR DESCRIPTION
-allowed onItemClick to be called when there is only one child in a carousel
- fixed corresponding test