### PR TITLE
[WIP] Add aria label to arrow buttons to avoid lighthouse complains

### DIFF
--- a/lib/components/Carousel.js
+++ b/lib/components/Carousel.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
     value: true
@@ -8,35 +8,35 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _react = require('react');
+var _react = require("react");
 
 var _react2 = _interopRequireDefault(_react);
 
-var _reactDom = require('react-dom');
+var _reactDom = require("react-dom");
 
 var _reactDom2 = _interopRequireDefault(_reactDom);
 
-var _propTypes = require('prop-types');
+var _propTypes = require("prop-types");
 
 var _propTypes2 = _interopRequireDefault(_propTypes);
 
-var _cssClasses = require('../cssClasses');
+var _cssClasses = require("../cssClasses");
 
 var _cssClasses2 = _interopRequireDefault(_cssClasses);
 
-var _CSSTranslate = require('../CSSTranslate');
+var _CSSTranslate = require("../CSSTranslate");
 
 var _CSSTranslate2 = _interopRequireDefault(_CSSTranslate);
 
-var _reactEasySwipe = require('react-easy-swipe');
+var _reactEasySwipe = require("react-easy-swipe");
 
 var _reactEasySwipe2 = _interopRequireDefault(_reactEasySwipe);
 
-var _Thumbs = require('./Thumbs');
+var _Thumbs = require("./Thumbs");
 
 var _Thumbs2 = _interopRequireDefault(_Thumbs);
 
-var _customPropTypes = require('../customPropTypes');
+var _customPropTypes = require("../customPropTypes");
 
 var customPropTypes = _interopRequireWildcard(_customPropTypes);
 
@@ -53,7 +53,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var noop = function noop() {};
 
 var defaultStatusFormatter = function defaultStatusFormatter(current, total) {
-    return current + ' of ' + total;
+    return current + " of " + total;
 };
 
 var Carousel = function (_Component) {
@@ -77,7 +77,7 @@ var Carousel = function (_Component) {
     }
 
     _createClass(Carousel, [{
-        key: 'componentDidMount',
+        key: "componentDidMount",
         value: function componentDidMount() {
             if (!this.props.children) {
                 return;
@@ -86,7 +86,7 @@ var Carousel = function (_Component) {
             this.setupCarousel();
         }
     }, {
-        key: 'componentWillReceiveProps',
+        key: "componentWillReceiveProps",
         value: function componentWillReceiveProps(nextProps) {
             var _this2 = this;
 
@@ -108,7 +108,7 @@ var Carousel = function (_Component) {
             }
         }
     }, {
-        key: 'componentDidUpdate',
+        key: "componentDidUpdate",
         value: function componentDidUpdate(prevProps, prevState) {
             if (!prevProps.children && this.props.children && !this.state.initialized) {
                 this.setupCarousel();
@@ -119,12 +119,12 @@ var Carousel = function (_Component) {
             }
         }
     }, {
-        key: 'componentWillUnmount',
+        key: "componentWillUnmount",
         value: function componentWillUnmount() {
             this.destroyCarousel();
         }
     }, {
-        key: 'setupCarousel',
+        key: "setupCarousel",
         value: function setupCarousel() {
             this.bindEvents();
 
@@ -139,13 +139,13 @@ var Carousel = function (_Component) {
             var initialImage = this.getInitialImage();
             if (initialImage) {
                 // if it's a carousel of images, we set the mount state after the first image is loaded
-                initialImage.addEventListener('load', this.setMountState);
+                initialImage.addEventListener("load", this.setMountState);
             } else {
                 this.setMountState();
             }
         }
     }, {
-        key: 'destroyCarousel',
+        key: "destroyCarousel",
         value: function destroyCarousel() {
             if (this.state.initialized) {
                 this.unbindEvents();
@@ -153,29 +153,29 @@ var Carousel = function (_Component) {
             }
         }
     }, {
-        key: 'setupAutoPlay',
+        key: "setupAutoPlay",
         value: function setupAutoPlay() {
             this.autoPlay();
             var carouselWrapper = this.carouselWrapperRef;
 
             if (this.props.stopOnHover && carouselWrapper) {
-                carouselWrapper.addEventListener('mouseenter', this.stopOnHover);
-                carouselWrapper.addEventListener('mouseleave', this.startOnLeave);
+                carouselWrapper.addEventListener("mouseenter", this.stopOnHover);
+                carouselWrapper.addEventListener("mouseleave", this.startOnLeave);
             }
         }
     }, {
-        key: 'destroyAutoPlay',
+        key: "destroyAutoPlay",
         value: function destroyAutoPlay() {
             this.clearAutoPlay();
             var carouselWrapper = this.carouselWrapperRef;
 
             if (this.props.stopOnHover && carouselWrapper) {
-                carouselWrapper.removeEventListener('mouseenter', this.stopOnHover);
-                carouselWrapper.removeEventListener('mouseleave', this.startOnLeave);
+                carouselWrapper.removeEventListener("mouseenter", this.stopOnHover);
+                carouselWrapper.removeEventListener("mouseleave", this.startOnLeave);
             }
         }
     }, {
-        key: 'bindEvents',
+        key: "bindEvents",
         value: function bindEvents() {
             // as the widths are calculated, we need to resize
             // the carousel when the window is resized
@@ -188,7 +188,7 @@ var Carousel = function (_Component) {
             }
         }
     }, {
-        key: 'unbindEvents',
+        key: "unbindEvents",
         value: function unbindEvents() {
             // removing listeners
             window.removeEventListener("resize", this.updateSizes);
@@ -204,14 +204,14 @@ var Carousel = function (_Component) {
             }
         }
     }, {
-        key: 'getPosition',
+        key: "getPosition",
         value: function getPosition(index) {
             if (this.props.infiniteLoop) {
                 // index has to be added by 1 because of the first cloned slide
                 ++index;
             }
             var childrenLength = _react.Children.count(this.props.children);
-            if (this.props.centerMode && this.props.axis === 'horizontal') {
+            if (this.props.centerMode && this.props.axis === "horizontal") {
                 var currentPosition = -index * this.props.centerSlidePercentage;
                 var lastPosition = childrenLength - 1;
 
@@ -227,7 +227,7 @@ var Carousel = function (_Component) {
             return -index * 100;
         }
     }, {
-        key: 'renderItems',
+        key: "renderItems",
         value: function renderItems(isClone) {
             var _this3 = this;
 
@@ -236,26 +236,26 @@ var Carousel = function (_Component) {
                     ref: function ref(e) {
                         return _this3.setItemsRef(e, index);
                     },
-                    key: 'itemKey' + index + (isClone ? 'clone' : ''),
+                    key: "itemKey" + index + (isClone ? "clone" : ""),
                     className: _cssClasses2.default.ITEM(true, index === _this3.state.selectedItem),
                     onClick: _this3.handleClickItem.bind(_this3, index, item)
                 };
 
-                if (_this3.props.centerMode && _this3.props.axis === 'horizontal') {
+                if (_this3.props.centerMode && _this3.props.axis === "horizontal") {
                     slideProps.style = {
-                        minWidth: _this3.props.centerSlidePercentage + '%'
+                        minWidth: _this3.props.centerSlidePercentage + "%"
                     };
                 }
 
                 return _react2.default.createElement(
-                    'li',
+                    "li",
                     slideProps,
                     item
                 );
             });
         }
     }, {
-        key: 'renderControls',
+        key: "renderControls",
         value: function renderControls() {
             var _this4 = this;
 
@@ -264,28 +264,36 @@ var Carousel = function (_Component) {
             }
 
             return _react2.default.createElement(
-                'ul',
-                { className: 'control-dots' },
+                "ul",
+                { className: "control-dots" },
                 _react.Children.map(this.props.children, function (item, index) {
-                    return _react2.default.createElement('li', { className: _cssClasses2.default.DOT(index === _this4.state.selectedItem), onClick: _this4.changeItem, onKeyDown: _this4.changeItem, value: index, key: index, role: 'button', tabIndex: 0 });
+                    return _react2.default.createElement("li", {
+                        className: _cssClasses2.default.DOT(index === _this4.state.selectedItem),
+                        onClick: _this4.changeItem,
+                        onKeyDown: _this4.changeItem,
+                        value: index,
+                        key: index,
+                        role: "button",
+                        tabIndex: 0
+                    });
                 })
             );
         }
     }, {
-        key: 'renderStatus',
+        key: "renderStatus",
         value: function renderStatus() {
             if (!this.props.showStatus) {
                 return null;
             }
 
             return _react2.default.createElement(
-                'p',
-                { className: 'carousel-status' },
+                "p",
+                { className: "carousel-status" },
                 this.props.statusFormatter(this.state.selectedItem + 1, _react.Children.count(this.props.children))
             );
         }
     }, {
-        key: 'renderThumbs',
+        key: "renderThumbs",
         value: function renderThumbs() {
             if (!this.props.showThumbs || _react.Children.count(this.props.children) === 0) {
                 return null;
@@ -293,18 +301,24 @@ var Carousel = function (_Component) {
 
             return _react2.default.createElement(
                 _Thumbs2.default,
-                { ref: this.setThumbsRef, onSelectItem: this.handleClickThumb, selectedItem: this.state.selectedItem, transitionTime: this.props.transitionTime, thumbWidth: this.props.thumbWidth },
+                {
+                    ref: this.setThumbsRef,
+                    onSelectItem: this.handleClickThumb,
+                    selectedItem: this.state.selectedItem,
+                    transitionTime: this.props.transitionTime,
+                    thumbWidth: this.props.thumbWidth
+                },
                 this.props.children
             );
         }
     }, {
-        key: 'render',
+        key: "render",
         value: function render() {
             if (!this.props.children || _react.Children.count(this.props.children) === 0) {
                 return null;
             }
 
-            var isHorizontal = this.props.axis === 'horizontal';
+            var isHorizontal = this.props.axis === "horizontal";
 
             var canShowArrows = this.props.showArrows && _react.Children.count(this.props.children) > 1;
 
@@ -318,27 +332,27 @@ var Carousel = function (_Component) {
             var currentPosition = this.getPosition(this.state.selectedItem);
 
             // if 3d is available, let's take advantage of the performance of transform
-            var transformProp = (0, _CSSTranslate2.default)(currentPosition + '%', this.props.axis);
+            var transformProp = (0, _CSSTranslate2.default)(currentPosition + "%", this.props.axis);
 
-            var transitionTime = this.props.transitionTime + 'ms';
+            var transitionTime = this.props.transitionTime + "ms";
 
             itemListStyles = {
-                'WebkitTransform': transformProp,
-                'MozTransform': transformProp,
-                'MsTransform': transformProp,
-                'OTransform': transformProp,
-                'transform': transformProp,
-                'msTransform': transformProp
+                WebkitTransform: transformProp,
+                MozTransform: transformProp,
+                MsTransform: transformProp,
+                OTransform: transformProp,
+                transform: transformProp,
+                msTransform: transformProp
             };
 
             if (!this.state.swiping) {
                 itemListStyles = _extends({}, itemListStyles, {
-                    'WebkitTransitionDuration': transitionTime,
-                    'MozTransitionDuration': transitionTime,
-                    'MsTransitionDuration': transitionTime,
-                    'OTransitionDuration': transitionTime,
-                    'transitionDuration': transitionTime,
-                    'msTransitionDuration': transitionTime
+                    WebkitTransitionDuration: transitionTime,
+                    MozTransitionDuration: transitionTime,
+                    MsTransitionDuration: transitionTime,
+                    OTransitionDuration: transitionTime,
+                    transitionDuration: transitionTime,
+                    msTransitionDuration: transitionTime
                 });
             }
 
@@ -364,47 +378,69 @@ var Carousel = function (_Component) {
 
                 if (this.props.dynamicHeight) {
                     var itemHeight = this.getVariableImageHeight(this.state.selectedItem);
-                    swiperProps.style.height = itemHeight || 'auto';
-                    containerStyles.height = itemHeight || 'auto';
+                    swiperProps.style.height = itemHeight || "auto";
+                    containerStyles.height = itemHeight || "auto";
                 }
             } else {
-                swiperProps.onSwipeUp = this.props.verticalSwipe === 'natural' ? this.onSwipeBackwards : this.onSwipeForward;
-                swiperProps.onSwipeDown = this.props.verticalSwipe === 'natural' ? this.onSwipeForward : this.onSwipeBackwards;
+                swiperProps.onSwipeUp = this.props.verticalSwipe === "natural" ? this.onSwipeBackwards : this.onSwipeForward;
+                swiperProps.onSwipeDown = this.props.verticalSwipe === "natural" ? this.onSwipeForward : this.onSwipeBackwards;
                 swiperProps.style.height = this.state.itemSize;
                 containerStyles.height = this.state.itemSize;
             }
             return _react2.default.createElement(
-                'div',
-                { className: this.props.className, ref: this.setCarouselWrapperRef },
+                "div",
+                {
+                    className: this.props.className,
+                    ref: this.setCarouselWrapperRef
+                },
                 _react2.default.createElement(
-                    'div',
-                    { className: _cssClasses2.default.CAROUSEL(true), style: { width: this.props.width } },
-                    _react2.default.createElement('button', { type: 'button', className: _cssClasses2.default.ARROW_PREV(!hasPrev), onClick: this.onClickPrev }),
+                    "div",
+                    {
+                        className: _cssClasses2.default.CAROUSEL(true),
+                        style: { width: this.props.width }
+                    },
+                    _react2.default.createElement("button", {
+                        "aria-label": "click-prev",
+                        type: "button",
+                        className: _cssClasses2.default.ARROW_PREV(!hasPrev),
+                        onClick: this.onClickPrev
+                    }),
                     _react2.default.createElement(
-                        'div',
-                        { className: _cssClasses2.default.WRAPPER(true, this.props.axis), style: containerStyles, ref: this.setItemsWrapperRef },
+                        "div",
+                        {
+                            className: _cssClasses2.default.WRAPPER(true, this.props.axis),
+                            style: containerStyles,
+                            ref: this.setItemsWrapperRef
+                        },
                         this.props.swipeable ? _react2.default.createElement(
                             _reactEasySwipe2.default,
                             _extends({
-                                tagName: 'ul',
+                                tagName: "ul",
                                 ref: this.setListRef
                             }, swiperProps, {
-                                allowMouseEvents: this.props.emulateTouch }),
+                                allowMouseEvents: this.props.emulateTouch
+                            }),
                             this.props.infiniteLoop && lastClone,
                             this.renderItems(),
                             this.props.infiniteLoop && firstClone
                         ) : _react2.default.createElement(
-                            'ul',
+                            "ul",
                             {
                                 className: _cssClasses2.default.SLIDER(true, this.state.swiping),
                                 ref: this.setListRef,
-                                style: itemListStyles },
+                                style: itemListStyles
+                            },
                             this.props.infiniteLoop && lastClone,
                             this.renderItems(),
                             this.props.infiniteLoop && firstClone
                         )
                     ),
-                    _react2.default.createElement('button', { type: 'button', className: _cssClasses2.default.ARROW_NEXT(!hasNext), onClick: this.onClickNext }),
+                    _react2.default.createElement("button", {
+                        "aria-label": "click-next",
+                        type: "button",
+                        className: _cssClasses2.default.ARROW_NEXT(!hasNext),
+                        onClick: this.onClickNext
+                    }),
                     this.renderControls(),
                     this.renderStatus()
                 ),
@@ -416,7 +452,7 @@ var Carousel = function (_Component) {
     return Carousel;
 }(_react.Component);
 
-Carousel.displayName = 'Carousel';
+Carousel.displayName = "Carousel";
 Carousel.propTypes = {
     className: _propTypes2.default.string,
     children: _propTypes2.default.node,
@@ -430,8 +466,8 @@ Carousel.propTypes = {
     onClickItem: _propTypes2.default.func.isRequired,
     onClickThumb: _propTypes2.default.func.isRequired,
     onChange: _propTypes2.default.func.isRequired,
-    axis: _propTypes2.default.oneOf(['horizontal', 'vertical']),
-    verticalSwipe: _propTypes2.default.oneOf(['natural', 'standard']),
+    axis: _propTypes2.default.oneOf(["horizontal", "vertical"]),
+    verticalSwipe: _propTypes2.default.oneOf(["natural", "standard"]),
     width: customPropTypes.unit,
     useKeyboardArrows: _propTypes2.default.bool,
     autoPlay: _propTypes2.default.bool,
@@ -453,9 +489,9 @@ Carousel.defaultProps = {
     showThumbs: true,
     infiniteLoop: false,
     selectedItem: 0,
-    axis: 'horizontal',
-    verticalSwipe: 'standard',
-    width: '100%',
+    axis: "horizontal",
+    verticalSwipe: "standard",
+    width: "100%",
     useKeyboardArrows: false,
     autoPlay: false,
     stopOnHover: true,
@@ -536,7 +572,7 @@ var _initialiseProps = function _initialiseProps() {
     this.navigateWithKeyboard = function (e) {
         var axis = _this5.props.axis;
 
-        var isHorizontal = axis === 'horizontal';
+        var isHorizontal = axis === "horizontal";
         var keyNames = {
             ArrowUp: 38,
             ArrowRight: 39,
@@ -559,7 +595,7 @@ var _initialiseProps = function _initialiseProps() {
             return;
         }
 
-        var isHorizontal = _this5.props.axis === 'horizontal';
+        var isHorizontal = _this5.props.axis === "horizontal";
         var firstItem = _this5.itemsRef[0];
         var itemSize = isHorizontal ? firstItem.clientWidth : firstItem.clientHeight;
 
@@ -633,7 +669,7 @@ var _initialiseProps = function _initialiseProps() {
     };
 
     this.onSwipeMove = function (delta) {
-        var isHorizontal = _this5.props.axis === 'horizontal';
+        var isHorizontal = _this5.props.axis === "horizontal";
         var childrenLength = _react.Children.count(_this5.props.children);
 
         var initialBoundry = 0;
@@ -664,7 +700,7 @@ var _initialiseProps = function _initialiseProps() {
                 position += childrenLength * 100;
             }
         }
-        position += '%';
+        position += "%";
         _this5.setPosition(position);
 
         // allows scroll if the swipe was within the tolerance
@@ -681,7 +717,7 @@ var _initialiseProps = function _initialiseProps() {
 
     this.setPosition = function (position, forceReflow) {
         var list = _reactDom2.default.findDOMNode(_this5.listRef);
-        ['WebkitTransform', 'MozTransform', 'MsTransform', 'OTransform', 'transform', 'msTransform'].forEach(function (prop) {
+        ["WebkitTransform", "MozTransform", "MsTransform", "OTransform", "transform", "msTransform"].forEach(function (prop) {
             list.style[prop] = (0, _CSSTranslate2.default)(position, _this5.props.axis);
         });
         if (forceReflow) {
@@ -690,7 +726,7 @@ var _initialiseProps = function _initialiseProps() {
     };
 
     this.resetPosition = function () {
-        var currentPosition = _this5.getPosition(_this5.state.selectedItem) + '%';
+        var currentPosition = _this5.getPosition(_this5.state.selectedItem) + "%";
         _this5.setPosition(currentPosition);
     };
 
@@ -698,14 +734,14 @@ var _initialiseProps = function _initialiseProps() {
         var positions = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 1;
         var fromSwipe = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
 
-        _this5.moveTo(_this5.state.selectedItem - (typeof positions === 'number' ? positions : 1), fromSwipe);
+        _this5.moveTo(_this5.state.selectedItem - (typeof positions === "number" ? positions : 1), fromSwipe);
     };
 
     this.increment = function () {
         var positions = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 1;
         var fromSwipe = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
 
-        _this5.moveTo(_this5.state.selectedItem + (typeof positions === 'number' ? positions : 1), fromSwipe);
+        _this5.moveTo(_this5.state.selectedItem + (typeof positions === "number" ? positions : 1), fromSwipe);
     };
 
     this.moveTo = function (position, fromSwipe) {
@@ -728,10 +764,10 @@ var _initialiseProps = function _initialiseProps() {
                 swiping: true
             }, function () {
                 if (oldPosition < 0) {
-                    if (_this5.props.centerMode && _this5.props.axis === 'horizontal') {
-                        _this5.setPosition('-' + ((lastPosition + 2) * _this5.props.centerSlidePercentage - (100 - _this5.props.centerSlidePercentage) / 2) + '%', true);
+                    if (_this5.props.centerMode && _this5.props.axis === "horizontal") {
+                        _this5.setPosition("-" + ((lastPosition + 2) * _this5.props.centerSlidePercentage - (100 - _this5.props.centerSlidePercentage) / 2) + "%", true);
                     } else {
-                        _this5.setPosition('-' + (lastPosition + 2) * 100 + '%', true);
+                        _this5.setPosition("-" + (lastPosition + 2) * 100 + "%", true);
                     }
                 } else if (oldPosition > lastPosition) {
                     _this5.setPosition(0, true);
@@ -773,7 +809,7 @@ var _initialiseProps = function _initialiseProps() {
     };
 
     this.changeItem = function (e) {
-        if (!e.key || e.key === 'Enter') {
+        if (!e.key || e.key === "Enter") {
             var newIndex = e.target.value;
 
             _this5.selectItem({
@@ -790,13 +826,13 @@ var _initialiseProps = function _initialiseProps() {
     this.getInitialImage = function () {
         var selectedItem = _this5.props.selectedItem;
         var item = _this5.itemsRef && _this5.itemsRef[selectedItem];
-        var images = item && item.getElementsByTagName('img');
+        var images = item && item.getElementsByTagName("img");
         return images && images[selectedItem];
     };
 
     this.getVariableImageHeight = function (position) {
         var item = _this5.itemsRef && _this5.itemsRef[position];
-        var images = item && item.getElementsByTagName('img');
+        var images = item && item.getElementsByTagName("img");
         if (_this5.state.hasMount && images.length > 0) {
             var image = images[0];
 
@@ -804,10 +840,10 @@ var _initialiseProps = function _initialiseProps() {
                 // if the image is still loading, the size won't be available so we trigger a new render after it's done
                 var onImageLoad = function onImageLoad() {
                     _this5.forceUpdate();
-                    image.removeEventListener('load', onImageLoad);
+                    image.removeEventListener("load", onImageLoad);
                 };
 
-                image.addEventListener('load', onImageLoad);
+                image.addEventListener("load", onImageLoad);
             }
 
             var height = image.clientHeight;

--- a/src/__tests__/__snapshots__/Carousel.js.snap
+++ b/src/__tests__/__snapshots__/Carousel.js.snap
@@ -13,6 +13,7 @@ exports[`Slider Snapshots center mode 1`] = `
     }
   >
     <button
+      aria-label="click-prev"
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
@@ -137,6 +138,7 @@ exports[`Slider Snapshots center mode 1`] = `
       </ul>
     </div>
     <button
+      aria-label="click-next"
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
@@ -214,6 +216,7 @@ exports[`Slider Snapshots center mode 1`] = `
       className="thumbs-wrapper axis-vertical"
     >
       <button
+        aria-label="click-prev"
         className="control-arrow control-prev control-disabled"
         onClick={[Function]}
         type="button"
@@ -320,6 +323,7 @@ exports[`Slider Snapshots center mode 1`] = `
         </li>
       </ul>
       <button
+        aria-label="click-next"
         className="control-arrow control-next control-disabled"
         onClick={[Function]}
         type="button"
@@ -342,6 +346,7 @@ exports[`Slider Snapshots custom class name 1`] = `
     }
   >
     <button
+      aria-label="click-prev"
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
@@ -431,6 +436,7 @@ exports[`Slider Snapshots custom class name 1`] = `
       </ul>
     </div>
     <button
+        aria-label="click-next"
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
@@ -508,6 +514,7 @@ exports[`Slider Snapshots custom class name 1`] = `
       className="thumbs-wrapper axis-vertical"
     >
       <button
+        aria-label="click-prev"
         className="control-arrow control-prev control-disabled"
         onClick={[Function]}
         type="button"
@@ -614,6 +621,7 @@ exports[`Slider Snapshots custom class name 1`] = `
         </li>
       </ul>
       <button
+        aria-label="click-next"
         className="control-arrow control-next control-disabled"
         onClick={[Function]}
         type="button"
@@ -636,6 +644,7 @@ exports[`Slider Snapshots custom width 1`] = `
     }
   >
     <button
+      aria-label="click-prev"
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
@@ -725,6 +734,7 @@ exports[`Slider Snapshots custom width 1`] = `
       </ul>
     </div>
     <button
+        aria-label="click-next"
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
@@ -802,6 +812,7 @@ exports[`Slider Snapshots custom width 1`] = `
       className="thumbs-wrapper axis-vertical"
     >
       <button
+        aria-label="click-prev"
         className="control-arrow control-prev control-disabled"
         onClick={[Function]}
         type="button"
@@ -908,6 +919,7 @@ exports[`Slider Snapshots custom width 1`] = `
         </li>
       </ul>
       <button
+        aria-label="click-next"
         className="control-arrow control-next control-disabled"
         onClick={[Function]}
         type="button"
@@ -930,6 +942,7 @@ exports[`Slider Snapshots default 1`] = `
     }
   >
     <button
+      aria-label="click-prev"
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
@@ -1019,6 +1032,7 @@ exports[`Slider Snapshots default 1`] = `
       </ul>
     </div>
     <button
+      aria-label="click-next"
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
@@ -1096,6 +1110,7 @@ exports[`Slider Snapshots default 1`] = `
       className="thumbs-wrapper axis-vertical"
     >
       <button
+        aria-label="click-prev"
         className="control-arrow control-prev control-disabled"
         onClick={[Function]}
         type="button"
@@ -1202,6 +1217,7 @@ exports[`Slider Snapshots default 1`] = `
         </li>
       </ul>
       <button
+        aria-label="click-next"
         className="control-arrow control-next control-disabled"
         onClick={[Function]}
         type="button"
@@ -1224,6 +1240,7 @@ exports[`Slider Snapshots infinite loop 1`] = `
     }
   >
     <button
+      aria-label="click-prev"
       className="control-arrow control-prev"
       onClick={[Function]}
       type="button"
@@ -1329,6 +1346,7 @@ exports[`Slider Snapshots infinite loop 1`] = `
       </ul>
     </div>
     <button
+      aria-label="click-next"
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
@@ -1406,6 +1424,7 @@ exports[`Slider Snapshots infinite loop 1`] = `
       className="thumbs-wrapper axis-vertical"
     >
       <button
+        aria-label="click-prev"
         className="control-arrow control-prev control-disabled"
         onClick={[Function]}
         type="button"
@@ -1512,6 +1531,7 @@ exports[`Slider Snapshots infinite loop 1`] = `
         </li>
       </ul>
       <button
+        aria-label="click-next"
         className="control-arrow control-next control-disabled"
         onClick={[Function]}
         type="button"
@@ -1534,6 +1554,7 @@ exports[`Slider Snapshots no arrows 1`] = `
     }
   >
     <button
+      aria-label="click-prev"
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
@@ -1623,6 +1644,7 @@ exports[`Slider Snapshots no arrows 1`] = `
       </ul>
     </div>
     <button
+      aria-label="click-next"
       className="control-arrow control-next control-disabled"
       onClick={[Function]}
       type="button"
@@ -1700,6 +1722,7 @@ exports[`Slider Snapshots no arrows 1`] = `
       className="thumbs-wrapper axis-vertical"
     >
       <button
+        aria-label="click-prev"
         className="control-arrow control-prev control-disabled"
         onClick={[Function]}
         type="button"
@@ -1806,6 +1829,7 @@ exports[`Slider Snapshots no arrows 1`] = `
         </li>
       </ul>
       <button
+        aria-label="click-next"
         className="control-arrow control-next control-disabled"
         onClick={[Function]}
         type="button"
@@ -1830,6 +1854,7 @@ exports[`Slider Snapshots no indicators 1`] = `
     }
   >
     <button
+      aria-label="click-prev"
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
@@ -1919,6 +1944,7 @@ exports[`Slider Snapshots no indicators 1`] = `
       </ul>
     </div>
     <button
+      aria-label="click-next"
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
@@ -1936,6 +1962,7 @@ exports[`Slider Snapshots no indicators 1`] = `
       className="thumbs-wrapper axis-vertical"
     >
       <button
+        aria-label="click-prev"
         className="control-arrow control-prev control-disabled"
         onClick={[Function]}
         type="button"
@@ -2042,6 +2069,7 @@ exports[`Slider Snapshots no indicators 1`] = `
         </li>
       </ul>
       <button
+        aria-label="click-next"
         className="control-arrow control-next control-disabled"
         onClick={[Function]}
         type="button"
@@ -2064,6 +2092,7 @@ exports[`Slider Snapshots no indicators 2`] = `
     }
   >
     <button
+      aria-label="click-prev"
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
@@ -2153,6 +2182,7 @@ exports[`Slider Snapshots no indicators 2`] = `
       </ul>
     </div>
     <button
+      aria-label="click-next"
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
@@ -2225,6 +2255,7 @@ exports[`Slider Snapshots no indicators 2`] = `
       className="thumbs-wrapper axis-vertical"
     >
       <button
+        aria-label="click-prev"
         className="control-arrow control-prev control-disabled"
         onClick={[Function]}
         type="button"
@@ -2331,6 +2362,7 @@ exports[`Slider Snapshots no indicators 2`] = `
         </li>
       </ul>
       <button
+        aria-label="click-next"
         className="control-arrow control-next control-disabled"
         onClick={[Function]}
         type="button"
@@ -2353,6 +2385,7 @@ exports[`Slider Snapshots no thumbs 1`] = `
     }
   >
     <button
+      aria-label="click-prev"
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
@@ -2442,6 +2475,7 @@ exports[`Slider Snapshots no thumbs 1`] = `
       </ul>
     </div>
     <button
+      aria-label="click-next"
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
@@ -2528,6 +2562,7 @@ exports[`Slider Snapshots swipeable false 1`] = `
     }
   >
     <button
+      aria-label="click-prev"
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
@@ -2614,6 +2649,7 @@ exports[`Slider Snapshots swipeable false 1`] = `
       </ul>
     </div>
     <button
+      aria-label="click-next"
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
@@ -2691,6 +2727,7 @@ exports[`Slider Snapshots swipeable false 1`] = `
       className="thumbs-wrapper axis-vertical"
     >
       <button
+        aria-label="click-prev"
         className="control-arrow control-prev control-disabled"
         onClick={[Function]}
         type="button"
@@ -2797,6 +2834,7 @@ exports[`Slider Snapshots swipeable false 1`] = `
         </li>
       </ul>
       <button
+        aria-label="click-next"
         className="control-arrow control-next control-disabled"
         onClick={[Function]}
         type="button"
@@ -2819,6 +2857,7 @@ exports[`Slider Snapshots vertical axis 1`] = `
     }
   >
     <button
+      aria-label="click-prev"
       className="control-arrow control-prev control-disabled"
       onClick={[Function]}
       type="button"
@@ -2913,6 +2952,7 @@ exports[`Slider Snapshots vertical axis 1`] = `
       </ul>
     </div>
     <button
+      aria-label="click-next"
       className="control-arrow control-next"
       onClick={[Function]}
       type="button"
@@ -2990,6 +3030,7 @@ exports[`Slider Snapshots vertical axis 1`] = `
       className="thumbs-wrapper axis-vertical"
     >
       <button
+        aria-label="click-prev"
         className="control-arrow control-prev control-disabled"
         onClick={[Function]}
         type="button"
@@ -3096,6 +3137,7 @@ exports[`Slider Snapshots vertical axis 1`] = `
         </li>
       </ul>
       <button
+        aria-label="click-next"
         className="control-arrow control-next control-disabled"
         onClick={[Function]}
         type="button"

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -1,18 +1,18 @@
-import React, { Component, Children } from 'react';
-import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
-import klass from '../cssClasses';
-import CSSTranslate from '../CSSTranslate';
-import Swipe from 'react-easy-swipe';
-import Thumbs from './Thumbs';
-import * as customPropTypes from '../customPropTypes';
+import React, { Component, Children } from "react";
+import ReactDOM from "react-dom";
+import PropTypes from "prop-types";
+import klass from "../cssClasses";
+import CSSTranslate from "../CSSTranslate";
+import Swipe from "react-easy-swipe";
+import Thumbs from "./Thumbs";
+import * as customPropTypes from "../customPropTypes";
 
 const noop = () => {};
 
 const defaultStatusFormatter = (current, total) => `${current} of ${total}`;
 
 class Carousel extends Component {
-    static displayName = 'Carousel';
+    static displayName = "Carousel";
 
     static propTypes = {
         className: PropTypes.string,
@@ -27,8 +27,8 @@ class Carousel extends Component {
         onClickItem: PropTypes.func.isRequired,
         onClickThumb: PropTypes.func.isRequired,
         onChange: PropTypes.func.isRequired,
-        axis: PropTypes.oneOf(['horizontal', 'vertical']),
-        verticalSwipe: PropTypes.oneOf(['natural', 'standard']),
+        axis: PropTypes.oneOf(["horizontal", "vertical"]),
+        verticalSwipe: PropTypes.oneOf(["natural", "standard"]),
         width: customPropTypes.unit,
         useKeyboardArrows: PropTypes.bool,
         autoPlay: PropTypes.bool,
@@ -47,13 +47,13 @@ class Carousel extends Component {
     static defaultProps = {
         showIndicators: true,
         showArrows: true,
-        showStatus:true,
-        showThumbs:true,
+        showStatus: true,
+        showThumbs: true,
         infiniteLoop: false,
         selectedItem: 0,
-        axis: 'horizontal',
-        verticalSwipe: 'standard',
-        width: '100%',
+        axis: "horizontal",
+        verticalSwipe: "standard",
+        width: "100%",
         useKeyboardArrows: false,
         autoPlay: false,
         stopOnHover: true,
@@ -83,7 +83,7 @@ class Carousel extends Component {
         };
     }
 
-    componentDidMount () {
+    componentDidMount() {
         if (!this.props.children) {
             return;
         }
@@ -91,27 +91,34 @@ class Carousel extends Component {
         this.setupCarousel();
     }
 
-    componentWillReceiveProps (nextProps) {
+    componentWillReceiveProps(nextProps) {
         if (nextProps.selectedItem !== this.state.selectedItem) {
             this.updateSizes();
             this.moveTo(nextProps.selectedItem);
         }
 
         if (nextProps.autoPlay !== this.state.autoPlay) {
-            this.setState({
-                autoPlay: nextProps.autoPlay
-            }, () => {
-                if (this.state.autoPlay) {
-                    this.setupAutoPlay();
-                } else {
-                    this.destroyAutoPlay();
+            this.setState(
+                {
+                    autoPlay: nextProps.autoPlay
+                },
+                () => {
+                    if (this.state.autoPlay) {
+                        this.setupAutoPlay();
+                    } else {
+                        this.destroyAutoPlay();
+                    }
                 }
-            });
+            );
         }
     }
 
     componentDidUpdate(prevProps, prevState) {
-        if (!prevProps.children && this.props.children && !this.state.initialized) {
+        if (
+            !prevProps.children &&
+            this.props.children &&
+            !this.state.initialized
+        ) {
             this.setupCarousel();
         }
         if (prevState.swiping && !this.state.swiping) {
@@ -126,28 +133,28 @@ class Carousel extends Component {
 
     setThumbsRef = node => {
         this.thumbsRef = node;
-    }
+    };
 
     setCarouselWrapperRef = node => {
         this.carouselWrapperRef = node;
-    }
+    };
 
     setListRef = node => {
         this.listRef = node;
-    }
+    };
 
     setItemsWrapperRef = node => {
         this.itemsWrapperRef = node;
-    }
+    };
 
     setItemsRef = (node, index) => {
         if (!this.itemsRef) {
             this.itemsRef = [];
         }
         this.itemsRef[index] = node;
-    }
+    };
 
-    setupCarousel () {
+    setupCarousel() {
         this.bindEvents();
 
         if (this.state.autoPlay && Children.count(this.props.children) > 1) {
@@ -158,43 +165,46 @@ class Carousel extends Component {
             initialized: true
         });
 
-        const initialImage = this.getInitialImage()
+        const initialImage = this.getInitialImage();
         if (initialImage) {
             // if it's a carousel of images, we set the mount state after the first image is loaded
-            initialImage.addEventListener('load', this.setMountState);
+            initialImage.addEventListener("load", this.setMountState);
         } else {
             this.setMountState();
         }
     }
 
-    destroyCarousel () {
+    destroyCarousel() {
         if (this.state.initialized) {
             this.unbindEvents();
             this.destroyAutoPlay();
         }
     }
 
-    setupAutoPlay () {
+    setupAutoPlay() {
         this.autoPlay();
         const carouselWrapper = this.carouselWrapperRef;
 
         if (this.props.stopOnHover && carouselWrapper) {
-            carouselWrapper.addEventListener('mouseenter', this.stopOnHover);
-            carouselWrapper.addEventListener('mouseleave', this.startOnLeave);
+            carouselWrapper.addEventListener("mouseenter", this.stopOnHover);
+            carouselWrapper.addEventListener("mouseleave", this.startOnLeave);
         }
     }
 
-    destroyAutoPlay () {
+    destroyAutoPlay() {
         this.clearAutoPlay();
         const carouselWrapper = this.carouselWrapperRef;
 
         if (this.props.stopOnHover && carouselWrapper) {
-            carouselWrapper.removeEventListener('mouseenter', this.stopOnHover);
-            carouselWrapper.removeEventListener('mouseleave', this.startOnLeave);
+            carouselWrapper.removeEventListener("mouseenter", this.stopOnHover);
+            carouselWrapper.removeEventListener(
+                "mouseleave",
+                this.startOnLeave
+            );
         }
     }
 
-    bindEvents () {
+    bindEvents() {
         // as the widths are calculated, we need to resize
         // the carousel when the window is resized
         window.addEventListener("resize", this.updateSizes);
@@ -206,13 +216,13 @@ class Carousel extends Component {
         }
     }
 
-    unbindEvents () {
+    unbindEvents() {
         // removing listeners
         window.removeEventListener("resize", this.updateSizes);
         window.removeEventListener("DOMContentLoaded", this.updateSizes);
 
         const initialImage = this.getInitialImage();
-        if(initialImage) {
+        if (initialImage) {
             initialImage.removeEventListener("load", this.setMountState);
         }
 
@@ -230,7 +240,7 @@ class Carousel extends Component {
         this.timer = setTimeout(() => {
             this.increment();
         }, this.props.interval);
-    }
+    };
 
     clearAutoPlay = () => {
         if (!this.state.autoPlay) {
@@ -238,26 +248,26 @@ class Carousel extends Component {
         }
 
         clearTimeout(this.timer);
-    }
+    };
 
     resetAutoPlay = () => {
         this.clearAutoPlay();
         this.autoPlay();
-    }
+    };
 
     stopOnHover = () => {
-        this.setState({isMouseEntered: true});
+        this.setState({ isMouseEntered: true });
         this.clearAutoPlay();
-    }
+    };
 
     startOnLeave = () => {
-        this.setState({isMouseEntered: false});
+        this.setState({ isMouseEntered: false });
         this.autoPlay();
-    }
+    };
 
-    navigateWithKeyboard = (e) => {
+    navigateWithKeyboard = e => {
         const { axis } = this.props;
-        const isHorizontal = axis === 'horizontal';
+        const isHorizontal = axis === "horizontal";
         const keyNames = {
             ArrowUp: 38,
             ArrowRight: 39,
@@ -273,31 +283,35 @@ class Carousel extends Component {
         } else if (prevKey === e.keyCode) {
             this.decrement();
         }
-    }
+    };
 
     updateSizes = () => {
         if (!this.state.initialized) {
             return;
         }
 
-        const isHorizontal = this.props.axis === 'horizontal';
+        const isHorizontal = this.props.axis === "horizontal";
         const firstItem = this.itemsRef[0];
-        const itemSize = isHorizontal ? firstItem.clientWidth : firstItem.clientHeight;
+        const itemSize = isHorizontal
+            ? firstItem.clientWidth
+            : firstItem.clientHeight;
 
         this.setState((_state, props) => ({
             itemSize: itemSize,
-            wrapperSize: isHorizontal ? itemSize * Children.count(props.children) : itemSize
+            wrapperSize: isHorizontal
+                ? itemSize * Children.count(props.children)
+                : itemSize
         }));
 
         if (this.thumbsRef) {
             this.thumbsRef.updateSizes();
         }
-    }
+    };
 
     setMountState = () => {
-        this.setState({hasMount: true});
+        this.setState({ hasMount: true });
         this.updateSizes();
-    }
+    };
 
     handleClickItem = (index, item) => {
         if (Children.count(this.props.children) == 0) {
@@ -316,10 +330,10 @@ class Carousel extends Component {
 
         if (index !== this.state.selectedItem) {
             this.setState({
-                selectedItem: index,
+                selectedItem: index
             });
         }
-    }
+    };
 
     handleOnChange = (index, item) => {
         if (Children.count(this.props.children) <= 1) {
@@ -327,7 +341,7 @@ class Carousel extends Component {
         }
 
         this.props.onChange(index, item);
-    }
+    };
 
     handleClickThumb = (index, item) => {
         this.props.onClickThumb(index, item);
@@ -335,30 +349,32 @@ class Carousel extends Component {
         this.selectItem({
             selectedItem: index
         });
-    }
+    };
 
     onSwipeStart = () => {
         this.setState({
-            swiping: true,
+            swiping: true
         });
         this.clearAutoPlay();
-    }
+    };
 
     onSwipeEnd = () => {
         this.setState({
             swiping: false
         });
         this.autoPlay();
-    }
+    };
 
-    onSwipeMove = (delta) => {
-        const isHorizontal = this.props.axis === 'horizontal';
+    onSwipeMove = delta => {
+        const isHorizontal = this.props.axis === "horizontal";
         const childrenLength = Children.count(this.props.children);
 
         const initialBoundry = 0;
 
         const currentPosition = this.getPosition(this.state.selectedItem);
-        const finalBoundry = this.props.infiniteLoop ? this.getPosition(childrenLength - 1) - 100 : this.getPosition(childrenLength - 1);
+        const finalBoundry = this.props.infiniteLoop
+            ? this.getPosition(childrenLength - 1) - 100
+            : this.getPosition(childrenLength - 1);
 
         const axisDelta = isHorizontal ? delta.x : delta.y;
         let handledDelta = axisDelta;
@@ -373,17 +389,21 @@ class Carousel extends Component {
             handledDelta = 0;
         }
 
-        let position = currentPosition + (100 / (this.state.itemSize / handledDelta));
+        let position =
+            currentPosition + 100 / (this.state.itemSize / handledDelta);
         if (this.props.infiniteLoop) {
             // When allowing infinite loop, if we slide left from position 0 we reveal the cloned last slide that appears before it
             // if we slide even further we need to jump to other side so it can continue - and vice versa for the last slide
             if (this.state.selectedItem === 0 && position > -100) {
                 position -= childrenLength * 100;
-            } else if (this.state.selectedItem === childrenLength - 1 && position <  - childrenLength * 100) {
+            } else if (
+                this.state.selectedItem === childrenLength - 1 &&
+                position < -childrenLength * 100
+            ) {
                 position += childrenLength * 100;
             }
         }
-        position += '%';
+        position += "%";
         this.setPosition(position);
 
         // allows scroll if the swipe was within the tolerance
@@ -396,7 +416,7 @@ class Carousel extends Component {
         }
 
         return hasMoved;
-    }
+    };
 
     getPosition(index) {
         if (this.props.infiniteLoop) {
@@ -404,86 +424,112 @@ class Carousel extends Component {
             ++index;
         }
         const childrenLength = Children.count(this.props.children);
-        if (this.props.centerMode && this.props.axis === 'horizontal') {
-            let currentPosition = - index * this.props.centerSlidePercentage;
+        if (this.props.centerMode && this.props.axis === "horizontal") {
+            let currentPosition = -index * this.props.centerSlidePercentage;
             const lastPosition = childrenLength - 1;
 
             if (index && (index !== lastPosition || this.props.infiniteLoop)) {
                 currentPosition += (100 - this.props.centerSlidePercentage) / 2;
             } else if (index === lastPosition) {
-                currentPosition += (100 - this.props.centerSlidePercentage);
+                currentPosition += 100 - this.props.centerSlidePercentage;
             }
 
             return currentPosition;
         }
 
-        return - index * 100;
+        return -index * 100;
     }
 
     setPosition = (position, forceReflow) => {
-        const list = ReactDOM.findDOMNode(this.listRef);        
+        const list = ReactDOM.findDOMNode(this.listRef);
         [
-            'WebkitTransform',
-            'MozTransform',
-            'MsTransform',
-            'OTransform',
-            'transform',
-            'msTransform'
-        ].forEach((prop) => {
+            "WebkitTransform",
+            "MozTransform",
+            "MsTransform",
+            "OTransform",
+            "transform",
+            "msTransform"
+        ].forEach(prop => {
             list.style[prop] = CSSTranslate(position, this.props.axis);
         });
         if (forceReflow) {
             list.offsetLeft;
         }
-    }
+    };
 
     resetPosition = () => {
-        const currentPosition = this.getPosition(this.state.selectedItem) + '%';
+        const currentPosition = this.getPosition(this.state.selectedItem) + "%";
         this.setPosition(currentPosition);
-    }
+    };
 
     decrement = (positions = 1, fromSwipe = false) => {
-        this.moveTo(this.state.selectedItem - (typeof positions === 'number' ? positions : 1), fromSwipe);
-    }
+        this.moveTo(
+            this.state.selectedItem -
+                (typeof positions === "number" ? positions : 1),
+            fromSwipe
+        );
+    };
 
     increment = (positions = 1, fromSwipe = false) => {
-        this.moveTo(this.state.selectedItem + (typeof positions === 'number' ? positions : 1), fromSwipe);
-    }
+        this.moveTo(
+            this.state.selectedItem +
+                (typeof positions === "number" ? positions : 1),
+            fromSwipe
+        );
+    };
 
-    moveTo = (position, fromSwipe) => {        
+    moveTo = (position, fromSwipe) => {
         const lastPosition = Children.count(this.props.children) - 1;
-        const needClonedSlide = this.props.infiniteLoop && !fromSwipe && (position < 0 || position > lastPosition);
+        const needClonedSlide =
+            this.props.infiniteLoop &&
+            !fromSwipe &&
+            (position < 0 || position > lastPosition);
         const oldPosition = position;
 
-        if (position < 0 ) {
-          position = this.props.infiniteLoop ?  lastPosition : 0;
+        if (position < 0) {
+            position = this.props.infiniteLoop ? lastPosition : 0;
         }
 
         if (position > lastPosition) {
-          position = this.props.infiniteLoop ? 0 : lastPosition;
+            position = this.props.infiniteLoop ? 0 : lastPosition;
         }
 
         if (needClonedSlide) {
             // set swiping true would disable transition time, then we set slider to cloned position and force a reflow
             // this is only needed for non-swiping situation
-            this.setState({
-                swiping: true
-            }, () => {
-                if (oldPosition < 0) {
-                    if (this.props.centerMode && this.props.axis === 'horizontal') {
-                        this.setPosition(`-${(lastPosition + 2) * this.props.centerSlidePercentage - (100 - this.props.centerSlidePercentage) / 2}%`, true);
-                    } else {
-                        this.setPosition(`-${(lastPosition + 2) * 100}%`, true);
+            this.setState(
+                {
+                    swiping: true
+                },
+                () => {
+                    if (oldPosition < 0) {
+                        if (
+                            this.props.centerMode &&
+                            this.props.axis === "horizontal"
+                        ) {
+                            this.setPosition(
+                                `-${(lastPosition + 2) *
+                                    this.props.centerSlidePercentage -
+                                    (100 - this.props.centerSlidePercentage) /
+                                        2}%`,
+                                true
+                            );
+                        } else {
+                            this.setPosition(
+                                `-${(lastPosition + 2) * 100}%`,
+                                true
+                            );
+                        }
+                    } else if (oldPosition > lastPosition) {
+                        this.setPosition(0, true);
                     }
-                } else if (oldPosition > lastPosition) {
-                    this.setPosition(0, true);
-                }
 
-                this.selectItem({
-                    selectedItem: position,
-                    swiping: false
-                });
-            });
+                    this.selectItem({
+                        selectedItem: position,
+                        swiping: false
+                    });
+                }
+            );
         } else {
             this.selectItem({
                 // if it's not a slider, we don't need to set position here
@@ -496,49 +542,52 @@ class Carousel extends Component {
         if (this.state.autoPlay && this.state.isMouseEntered === false) {
             this.resetAutoPlay();
         }
-    }
+    };
 
     onClickNext = () => {
         this.increment(1, false);
-    }
+    };
 
     onClickPrev = () => {
         this.decrement(1, false);
-    }
+    };
 
     onSwipeForward = () => {
         this.increment(1, true);
-    }
+    };
 
     onSwipeBackwards = () => {
         this.decrement(1, true);
-    }
+    };
 
-    changeItem = (e) => {
-        if (!e.key || e.key === 'Enter') {
+    changeItem = e => {
+        if (!e.key || e.key === "Enter") {
             const newIndex = e.target.value;
 
             this.selectItem({
                 selectedItem: newIndex
             });
         }
-    }
+    };
 
     selectItem = (state, cb) => {
         this.setState(state, cb);
-        this.handleOnChange(state.selectedItem, Children.toArray(this.props.children)[state.selectedItem]);
-    }
+        this.handleOnChange(
+            state.selectedItem,
+            Children.toArray(this.props.children)[state.selectedItem]
+        );
+    };
 
     getInitialImage = () => {
         const selectedItem = this.props.selectedItem;
         const item = this.itemsRef && this.itemsRef[selectedItem];
-        const images = item && item.getElementsByTagName('img');
+        const images = item && item.getElementsByTagName("img");
         return images && images[selectedItem];
-    }
+    };
 
-    getVariableImageHeight = (position) => {
+    getVariableImageHeight = position => {
         const item = this.itemsRef && this.itemsRef[position];
-        const images = item && item.getElementsByTagName('img');
+        const images = item && item.getElementsByTagName("img");
         if (this.state.hasMount && images.length > 0) {
             const image = images[0];
 
@@ -546,10 +595,10 @@ class Carousel extends Component {
                 // if the image is still loading, the size won't be available so we trigger a new render after it's done
                 const onImageLoad = () => {
                     this.forceUpdate();
-                    image.removeEventListener('load', onImageLoad);
-                }
+                    image.removeEventListener("load", onImageLoad);
+                };
 
-                image.addEventListener('load', onImageLoad);
+                image.addEventListener("load", onImageLoad);
             }
 
             const height = image.clientHeight;
@@ -557,106 +606,140 @@ class Carousel extends Component {
         }
 
         return null;
-    }
+    };
 
-    renderItems (isClone) {
+    renderItems(isClone) {
         return Children.map(this.props.children, (item, index) => {
             const slideProps = {
-                ref: (e) => this.setItemsRef(e, index),
-                key: 'itemKey' + index + (isClone ? 'clone' : ''),
+                ref: e => this.setItemsRef(e, index),
+                key: "itemKey" + index + (isClone ? "clone" : ""),
                 className: klass.ITEM(true, index === this.state.selectedItem),
                 onClick: this.handleClickItem.bind(this, index, item)
             };
 
-            if (this.props.centerMode && this.props.axis === 'horizontal') {
+            if (this.props.centerMode && this.props.axis === "horizontal") {
                 slideProps.style = {
-                    minWidth: this.props.centerSlidePercentage + '%'
+                    minWidth: this.props.centerSlidePercentage + "%"
                 };
             }
 
-            return (
-                <li {...slideProps}>
-                    { item }
-                </li>
-            );
+            return <li {...slideProps}>{item}</li>;
         });
     }
 
-    renderControls () {
+    renderControls() {
         if (!this.props.showIndicators) {
-            return null
+            return null;
         }
 
         return (
             <ul className="control-dots">
                 {Children.map(this.props.children, (item, index) => {
-                    return <li className={klass.DOT(index === this.state.selectedItem)} onClick={this.changeItem} onKeyDown={this.changeItem} value={index} key={index} role='button' tabIndex={0} />;
+                    return (
+                        <li
+                            className={klass.DOT(
+                                index === this.state.selectedItem
+                            )}
+                            onClick={this.changeItem}
+                            onKeyDown={this.changeItem}
+                            value={index}
+                            key={index}
+                            role="button"
+                            tabIndex={0}
+                        />
+                    );
                 })}
             </ul>
         );
     }
 
-    renderStatus () {
+    renderStatus() {
         if (!this.props.showStatus) {
-            return null
-        }
-
-        return <p className="carousel-status">{this.props.statusFormatter(this.state.selectedItem + 1, Children.count(this.props.children))}</p>;
-    }
-
-    renderThumbs () {
-        if (!this.props.showThumbs || Children.count(this.props.children) === 0) {
-            return null
+            return null;
         }
 
         return (
-            <Thumbs ref={this.setThumbsRef} onSelectItem={this.handleClickThumb} selectedItem={this.state.selectedItem} transitionTime={this.props.transitionTime} thumbWidth={this.props.thumbWidth}>
+            <p className="carousel-status">
+                {this.props.statusFormatter(
+                    this.state.selectedItem + 1,
+                    Children.count(this.props.children)
+                )}
+            </p>
+        );
+    }
+
+    renderThumbs() {
+        if (
+            !this.props.showThumbs ||
+            Children.count(this.props.children) === 0
+        ) {
+            return null;
+        }
+
+        return (
+            <Thumbs
+                ref={this.setThumbsRef}
+                onSelectItem={this.handleClickThumb}
+                selectedItem={this.state.selectedItem}
+                transitionTime={this.props.transitionTime}
+                thumbWidth={this.props.thumbWidth}
+            >
                 {this.props.children}
             </Thumbs>
         );
     }
 
-    render () {
+    render() {
         if (!this.props.children || Children.count(this.props.children) === 0) {
             return null;
         }
 
-        const isHorizontal = this.props.axis === 'horizontal';
+        const isHorizontal = this.props.axis === "horizontal";
 
-        const canShowArrows = this.props.showArrows && Children.count(this.props.children) > 1;
+        const canShowArrows =
+            this.props.showArrows && Children.count(this.props.children) > 1;
 
         // show left arrow?
-        const hasPrev = canShowArrows && (this.state.selectedItem > 0 || this.props.infiniteLoop);
+        const hasPrev =
+            canShowArrows &&
+            (this.state.selectedItem > 0 || this.props.infiniteLoop);
         // show right arrow
-        const hasNext = canShowArrows && (this.state.selectedItem < Children.count(this.props.children) - 1 || this.props.infiniteLoop);
+        const hasNext =
+            canShowArrows &&
+            (this.state.selectedItem <
+                Children.count(this.props.children) - 1 ||
+                this.props.infiniteLoop);
         // obj to hold the transformations and styles
         let itemListStyles = {};
 
         const currentPosition = this.getPosition(this.state.selectedItem);
 
         // if 3d is available, let's take advantage of the performance of transform
-        const transformProp = CSSTranslate(currentPosition + '%', this.props.axis);
+        const transformProp = CSSTranslate(
+            currentPosition + "%",
+            this.props.axis
+        );
 
-        const transitionTime = this.props.transitionTime + 'ms';
+        const transitionTime = this.props.transitionTime + "ms";
 
         itemListStyles = {
-                    'WebkitTransform': transformProp,
-                       'MozTransform': transformProp,
-                        'MsTransform': transformProp,
-                         'OTransform': transformProp,
-                          'transform': transformProp,
-                        'msTransform': transformProp
+            WebkitTransform: transformProp,
+            MozTransform: transformProp,
+            MsTransform: transformProp,
+            OTransform: transformProp,
+            transform: transformProp,
+            msTransform: transformProp
         };
 
         if (!this.state.swiping) {
             itemListStyles = {
                 ...itemListStyles,
-               'WebkitTransitionDuration': transitionTime,
-                  'MozTransitionDuration': transitionTime,
-                   'MsTransitionDuration': transitionTime,
-                    'OTransitionDuration': transitionTime,
-                     'transitionDuration': transitionTime,
-                   'msTransitionDuration': transitionTime
+                WebkitTransitionDuration: transitionTime,
+                MozTransitionDuration: transitionTime,
+                MsTransitionDuration: transitionTime,
+                OTransitionDuration: transitionTime,
+                transitionDuration: transitionTime,
+                msTransitionDuration: transitionTime
             };
         }
 
@@ -681,51 +764,83 @@ class Carousel extends Component {
             swiperProps.onSwipeRight = this.onSwipeBackwards;
 
             if (this.props.dynamicHeight) {
-                const itemHeight = this.getVariableImageHeight(this.state.selectedItem);
-                swiperProps.style.height = itemHeight || 'auto';
-                containerStyles.height = itemHeight || 'auto';
+                const itemHeight = this.getVariableImageHeight(
+                    this.state.selectedItem
+                );
+                swiperProps.style.height = itemHeight || "auto";
+                containerStyles.height = itemHeight || "auto";
             }
-
-        } else {            
-            swiperProps.onSwipeUp = this.props.verticalSwipe === 'natural' ? this.onSwipeBackwards : this.onSwipeForward;
-            swiperProps.onSwipeDown = this.props.verticalSwipe === 'natural' ? this.onSwipeForward : this.onSwipeBackwards;
+        } else {
+            swiperProps.onSwipeUp =
+                this.props.verticalSwipe === "natural"
+                    ? this.onSwipeBackwards
+                    : this.onSwipeForward;
+            swiperProps.onSwipeDown =
+                this.props.verticalSwipe === "natural"
+                    ? this.onSwipeForward
+                    : this.onSwipeBackwards;
             swiperProps.style.height = this.state.itemSize;
             containerStyles.height = this.state.itemSize;
         }
         return (
-            <div className={this.props.className} ref={this.setCarouselWrapperRef}>
-                <div className={klass.CAROUSEL(true)} style={{width: this.props.width}}>
-                    <button type="button" className={klass.ARROW_PREV(!hasPrev)} onClick={this.onClickPrev} />
-                    <div className={klass.WRAPPER(true, this.props.axis)} style={containerStyles} ref={this.setItemsWrapperRef}>
-                        { this.props.swipeable ?
+            <div
+                className={this.props.className}
+                ref={this.setCarouselWrapperRef}
+            >
+                <div
+                    className={klass.CAROUSEL(true)}
+                    style={{ width: this.props.width }}
+                >
+                    <button
+                        aria-label="click-prev"
+                        type="button"
+                        className={klass.ARROW_PREV(!hasPrev)}
+                        onClick={this.onClickPrev}
+                    />
+                    <div
+                        className={klass.WRAPPER(true, this.props.axis)}
+                        style={containerStyles}
+                        ref={this.setItemsWrapperRef}
+                    >
+                        {this.props.swipeable ? (
                             <Swipe
                                 tagName="ul"
                                 ref={this.setListRef}
                                 {...swiperProps}
-                                allowMouseEvents={this.props.emulateTouch}>
-                                { this.props.infiniteLoop && lastClone }
-                                { this.renderItems() }
-                                { this.props.infiniteLoop && firstClone }
-                            </Swipe> :
+                                allowMouseEvents={this.props.emulateTouch}
+                            >
+                                {this.props.infiniteLoop && lastClone}
+                                {this.renderItems()}
+                                {this.props.infiniteLoop && firstClone}
+                            </Swipe>
+                        ) : (
                             <ul
-                                className={klass.SLIDER(true, this.state.swiping)}
+                                className={klass.SLIDER(
+                                    true,
+                                    this.state.swiping
+                                )}
                                 ref={this.setListRef}
-                                style={itemListStyles}>
-                                { this.props.infiniteLoop && lastClone }
-                                { this.renderItems() }
-                                { this.props.infiniteLoop && firstClone }
+                                style={itemListStyles}
+                            >
+                                {this.props.infiniteLoop && lastClone}
+                                {this.renderItems()}
+                                {this.props.infiniteLoop && firstClone}
                             </ul>
-                        }
+                        )}
                     </div>
-                    <button type="button" className={klass.ARROW_NEXT(!hasNext)} onClick={this.onClickNext} />
+                    <button
+                        aria-label="click-next"
+                        type="button"
+                        className={klass.ARROW_NEXT(!hasNext)}
+                        onClick={this.onClickNext}
+                    />
 
-                    { this.renderControls() }
-                    { this.renderStatus() }
+                    {this.renderControls()}
+                    {this.renderStatus()}
                 </div>
-                { this.renderThumbs() }
+                {this.renderThumbs()}
             </div>
         );
-
     }
 }
 


### PR DESCRIPTION
Adds aria label to the button arrow used for changing the current active slide so that lighthouse doesn't complain about an empt button label. 

// TODO Revert the code style changes that my editor did automatically.
// TODO Make sure unit tests are passing

This is a WIP not ready to be reviewed. 