### PR TITLE
Issue #345 fix(onClickItem): cancelClick should be true when onSwipeEnd

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -300,7 +300,7 @@ class Carousel extends Component {
     }
 
     handleClickItem = (index, item) => {
-        if (Children.count(this.props.children) == 0) {
+        if (Children.count(this.props.children) === 0) {
             return;
         }
 
@@ -346,7 +346,8 @@ class Carousel extends Component {
 
     onSwipeEnd = () => {
         this.setState({
-            swiping: false
+            swiping: false,
+            cancelClick: false
         });
         this.autoPlay();
     }


### PR DESCRIPTION
fixed bug: #345 when has moved, onClickItem needed be clicked twice bug