### PR TITLE
Add callback on swipe events

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ ReactDOM.render(<DemoCarousel />, document.querySelector('.demo-carousel'));
 | labels | `object [key: string]: string`      | `{ leftArrow, rightArrow, item }` | optionally specify labels to be applied to controls |
 | onSwipeStart          | `function`    | - | Fired when a swiping gesture has started |
 | onSwipeEnd            | `function`    | - | Fired when a swiping gesture has ended |
-| onSwipeMove           | `function`    | - | Fired when a swiping gesture is happening|
+| onSwipeMove           | `function`    | - | Fired when a swiping gesture is happening |
 
 
 =======================

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ ReactDOM.render(<DemoCarousel />, document.querySelector('.demo-carousel'));
 | centerMode            | `boolean`     | `false` | Enables centered view with partial prev/next slides. Only works with horizontal axis. |
 | centerSlidePercentage | `number`      | `80` | optionally specify percentage width (as an integer) of the slides in `centerMode` |
 | labels | `object [key: string]: string`      | `{ leftArrow, rightArrow, item }` | optionally specify labels to be applied to controls |
+| onSwipeStart          | `function`    | - | Fired when a swiping gesture has started |
+| onSwipeEnd            | `function`    | - | Fired when a swiping gesture has ended |
+| onSwipeMove           | `function`    | - | Fired when a swiping gesture is happening|
 
 
 =======================

--- a/src/__tests__/Carousel.js
+++ b/src/__tests__/Carousel.js
@@ -639,6 +639,14 @@ describe("Slider", function() {
                 componentInstance.onSwipeStart();
                 expect(componentInstance.clearAutoPlay.mock.calls.length).toBe(1);
             });
+
+            it('should call onSwipeStart callback', () => {
+                var onSwipeStartFunction = jest.genMockFunction();
+                renderDefaultComponent({onSwipeStart: onSwipeStartFunction});
+
+                componentInstance.onSwipeStart();
+                expect(onSwipeStartFunction).toBeCalled();
+            });
         });
 
         describe('onSwipeMove', () => {
@@ -655,6 +663,14 @@ describe("Slider", function() {
                     y: 10
                 })).toBe(false);
             });
+
+            it('should call onSwipeMove callback', () => {
+                var onSwipeMoveFunction = jest.genMockFunction();
+                renderDefaultComponent({onSwipeMove: onSwipeMoveFunction});
+
+                componentInstance.onSwipeMove({ x: 0, y: 10 });
+                expect(onSwipeMoveFunction).toBeCalled();
+            });
         });
 
         describe('onSwipeEnd', () => {
@@ -666,6 +682,14 @@ describe("Slider", function() {
                 componentInstance.autoPlay = jest.genMockFunction();
                 componentInstance.onSwipeEnd();
                 expect(componentInstance.autoPlay.mock.calls.length).toBe(1);
+            });
+
+            it('should call onSwipeEnd callback', () => {
+                var onSwipeEndFunction = jest.genMockFunction();
+                renderDefaultComponent({onSwipeEnd: onSwipeEndFunction});
+
+                componentInstance.onSwipeEnd();
+                expect(onSwipeEndFunction).toBeCalled();
             });
         });
 

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -46,7 +46,10 @@ class Carousel extends Component {
             leftArrow: PropTypes.string,
             rightArrow: PropTypes.string,
             item: PropTypes.string
-        })
+        }),
+        onSwipeStart: PropTypes.func,
+        onSwipeEnd: PropTypes.func,
+        onSwipeMove: PropTypes.func
     };
 
     static defaultProps = {
@@ -78,7 +81,10 @@ class Carousel extends Component {
             leftArrow: 'previous slide / item',
             rightArrow: 'next slide / item',
             item: 'slide item'
-        }
+        },
+        onSwipeStart: () => {},
+        onSwipeEnd: () => {},
+        onSwipeMove: () => {}
     };
 
     constructor(props) {
@@ -351,6 +357,7 @@ class Carousel extends Component {
         this.setState({
             swiping: true,
         });
+        this.props.onSwipeStart();
         this.clearAutoPlay();
     }
 
@@ -359,10 +366,12 @@ class Carousel extends Component {
             swiping: false,
             cancelClick: false
         });
+        this.props.onSwipeEnd();
         this.autoPlay();
     }
 
     onSwipeMove = (delta) => {
+        this.props.onSwipeMove();
         const isHorizontal = this.props.axis === 'horizontal';
         const childrenLength = Children.count(this.props.children);
 

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -353,25 +353,25 @@ class Carousel extends Component {
         });
     }
 
-    onSwipeStart = () => {
+    onSwipeStart = (event) => {
         this.setState({
             swiping: true,
         });
-        this.props.onSwipeStart();
+        this.props.onSwipeStart(event);
         this.clearAutoPlay();
     }
 
-    onSwipeEnd = () => {
+    onSwipeEnd = (event) => {
         this.setState({
             swiping: false,
             cancelClick: false
         });
-        this.props.onSwipeEnd();
+        this.props.onSwipeEnd(event);
         this.autoPlay();
     }
 
-    onSwipeMove = (delta) => {
-        this.props.onSwipeMove();
+    onSwipeMove = (delta, event) => {
+        this.props.onSwipeMove(event);
         const isHorizontal = this.props.axis === 'horizontal';
         const childrenLength = Children.count(this.props.children);
 


### PR DESCRIPTION
This PR adds the following three props: onSwipeStart, onSwipeEnd and onSwipeMove. These functions are not required and can be added in order for the user to handle the events fired from react-easy-swipe during gestures.

A concrete example of this is related to the issue https://github.com/leandrowd/react-responsive-carousel/issues/365. On iOS physical devices, disabling the scroll of the body needs some extra configuration rather than _event.preventDefault()_ and these functions can then be utilised in order to turn of body scrolling during swiping.
