### PR TITLE
Fix TyperError warning cannot read property by updating Carousel.js: …

### DIFF
--- a/lib/components/Carousel.js
+++ b/lib/components/Carousel.js
@@ -148,8 +148,8 @@ var Carousel = function (_Component) {
             }
 
             var isHorizontal = _this.props.axis === 'horizontal';
-            var firstItem = _this.itemsRef[0];
-            var itemSize = isHorizontal ? firstItem.clientWidth : firstItem.clientHeight;
+            var firstItem = typeof _this.itemsRef !== 'undefined' ? _this.itemsRef[0] : undefined;
+            var itemSize = typeof firstItem !== 'undefined' ? (isHorizontal ? firstItem.clientWidth : firstItem.clientHeight) : 'undefined';
 
             _this.setState(function (_state, props) {
                 return {


### PR DESCRIPTION
…151-152

I was receiving this error -
Uncaught TypeError: Cannot read property '0' of undefined
    at n.updateSizes (Carousel.js:228)

It seemed that it was trying to update before data was received from my async call to the api that I was using to get photos from.