### PR TITLE
Fix dynamicHeight broken due to load event not triggered when the initial image is cached

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -173,17 +173,22 @@ class Carousel extends Component {
             this.setupAutoPlay();
         }
 
-        this.setState({
-            initialized: true,
-        });
-
-        const initialImage = this.getInitialImage();
-        if (initialImage) {
-            // if it's a carousel of images, we set the mount state after the first image is loaded
-            initialImage.addEventListener('load', this.setMountState);
-        } else {
-            this.setMountState();
-        }
+        this.setState(
+            {
+                initialized: true,
+            },
+            () => {
+                // use a callback since 'updateSizes()' depends on 'initialized' attribute
+                const initialImage = this.getInitialImage();
+                // when image is browser cached (i.e., true === initialImage.complete), "load" event is not triggered
+                if (initialImage && false === initialImage.complete) {
+                    // if it's a carousel of images, we set the mount state after the first image is loaded
+                    initialImage.addEventListener('load', this.setMountState);
+                } else {
+                    this.setMountState();
+                }
+            }
+        );
     }
 
     destroyCarousel() {


### PR DESCRIPTION
Fix #167

When image is cached by the browser, its 'load' event is not triggered. If dynamicHeight is used, the container size listens on the image load event and update. Since the load event is not triggered, the container height is not updated according to the initial image size.

This PR applies the workaround from: http://mikefowler.me/journal/2014/04/22/cached-images-load-event