### PR TITLE
Fixed mobile carousel slider

### DIFF
--- a/src/components/Thumbs.js
+++ b/src/components/Thumbs.js
@@ -203,7 +203,7 @@ class Thumbs extends Component {
         if (this.itemsListRef) {
             ['WebkitTransform', 'MozTransform', 'MsTransform', 'OTransform', 'transform', 'msTransform'].forEach(
                 (prop) => {
-                    this.itemsListRef.style[prop] = CSSTranslate(position, this.props.axis);
+                    this.itemsListRef.swiper.style[prop] = CSSTranslate(position, this.props.axis);
                 }
             );
         }


### PR DESCRIPTION
This commit is to fix the following error, on the mobile thumbnails carousel:
 'Cannot set property WebkitTransform of  undefined'

The solution is based on issue #382 

Thank you.