### PR TITLE
Fix thumbnails not swiping on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "dependencies": {
         "classnames": "^2.2.5",
         "prop-types": "^15.5.8",
-        "react-easy-swipe": "^0.0.16"
+        "react-easy-swipe": "^0.0.18"
     },
     "jest": {
         "unmockedModulePathPatterns": [

--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -709,7 +709,6 @@ class Carousel extends Component {
         const lastClone = itemsClone.pop();
 
         let swiperProps = {
-            selectedItem: this.state.selectedItem,
             className: klass.SLIDER(true, this.state.swiping),
             onSwipeMove: this.onSwipeMove,
             onSwipeStart: this.onSwipeStart,

--- a/src/components/Thumbs.js
+++ b/src/components/Thumbs.js
@@ -198,7 +198,6 @@ class Thumbs extends Component {
 
         const wrapperSize = this.itemsWrapperRef.clientWidth;
         const position = currentPosition + 100 / (wrapperSize / deltaX) + '%';
-
         // if 3d isn't available we will use left to move
         if (this.itemsListRef) {
             ['WebkitTransform', 'MozTransform', 'MsTransform', 'OTransform', 'transform', 'msTransform'].forEach(
@@ -317,7 +316,6 @@ class Thumbs extends Component {
                     />
                     <Swipe
                         tagName="ul"
-                        selectedItem={this.state.selectedItem}
                         className={klass.SLIDER(false, this.state.swiping)}
                         onSwipeLeft={this.slideLeft}
                         onSwipeRight={this.slideRight}
@@ -325,7 +323,7 @@ class Thumbs extends Component {
                         onSwipeStart={this.onSwipeStart}
                         onSwipeEnd={this.onSwipeEnd}
                         style={itemListStyles}
-                        ref={this.setItemsListRef}
+                        innerRef={this.setItemsListRef}
                     >
                         {this.renderItems()}
                     </Swipe>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7149,9 +7149,10 @@ react-dom@^15.5.4:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
-react-easy-swipe@^0.0.16:
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/react-easy-swipe/-/react-easy-swipe-0.0.16.tgz#5a3d949a8f975d05be92a818254315d1318a81ea"
+react-easy-swipe@^0.0.18:
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/react-easy-swipe/-/react-easy-swipe-0.0.18.tgz#3f52a05dbe3f8817bb8db94e743f6d966bbe89aa"
+  integrity sha512-IddCZANbT0qVbGFEihfWOkZb/rFpeA3VV87SNOOqPzmSZ93G0nDSyHD28zuGhYJilwEP33MqYv/dwo+zaZha3Q==
   dependencies:
     prop-types "^15.5.8"
 


### PR DESCRIPTION
Fixes issue #382.

Thanks @heyandrelima for creating https://github.com/leandrowd/react-responsive-carousel/pull/405 but the approach there depends on the internals of the react-easy-swipe not changing. 

The approach on this PR is safer. Please check if it solves your issue too and let me know if you still have problems.