### PR TITLE
Remove invalid value attribute

### DIFF
--- a/src/components/Carousel.js
+++ b/src/components/Carousel.js
@@ -102,7 +102,6 @@ class Carousel extends Component {
                     className={klass.DOT(isSelected)}
                     onClick={onClickHandler}
                     onKeyDown={onClickHandler}
-                    value={index}
                     key={index}
                     role="button"
                     tabIndex={0}


### PR DESCRIPTION
According to W3C validator `li` is not allowed to have a `value` attribute