### PR TITLE
#444 and #301: sets padding explicitly in .control-dots

### DIFF
--- a/src/components/_carousel.scss
+++ b/src/components/_carousel.scss
@@ -234,6 +234,7 @@
         position: absolute;
         bottom: 0;
         margin: 10px 0;
+        padding: 0;
         text-align: center;
         width: 100%;
 


### PR DESCRIPTION
`<ul>` element has padding specified in user agent stylesheet, so I set `padding: 0;` **explicitly** in `.control-dots`.