### PR TITLE
fix: link to storybook code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Powerful, lightweight and fully customizable carousel component for React apps.
 
 <http://leandrowd.github.io/react-responsive-carousel/>
 
-Check it out these [cool demos](http://react-responsive-carousel.js.org/storybook/index.html) created using [storybook](https://storybook.js.org/). The source code for each example is available [here](https://github.com/leandrowd/react-responsive-carousel/blob/master/stories/index.js)
+Check it out these [cool demos](http://react-responsive-carousel.js.org/storybook/index.html) created using [storybook](https://storybook.js.org/). The source code for each example is available [here](https://github.com/leandrowd/react-responsive-carousel/blob/master/stories/)
 
 Customize it yourself:
 


### PR DESCRIPTION
The link to code for storybook examples is broken in the README. I have redirected it to the `stories` folder instead of the unavailable `index.js` file 