### PR TITLE
fix: getInitialImage returns the first image of the selected item

### DIFF
--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -335,6 +335,19 @@ describe('Slider', function() {
         });
     });
 
+    describe('getInitialImage', () => {
+        it('Returns the first image within the declared selected item', () => {
+            renderDefaultComponent({
+                selectedItem: 2,
+            });
+
+            const initialImage = componentInstance.getInitialImage();
+            const expectedMatchingImageComponent = baseChildren[2];
+
+            expect(initialImage.src.endsWith(expectedMatchingImageComponent.props.src)).toEqual(true);
+        });
+    });
+
     describe('navigateWithKeyboard', () => {
         const setActiveElement = (element: HTMLElement) => {
             (document.activeElement as any) = element;

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -665,8 +665,8 @@ export default class Carousel extends React.Component<Props, State> {
     getInitialImage = () => {
         const selectedItem = this.props.selectedItem;
         const item = this.itemsRef && this.itemsRef[selectedItem];
-        const images = item && item.getElementsByTagName('img');
-        return images && images[selectedItem];
+        const images = (item && item.getElementsByTagName('img')) || [];
+        return images[0];
     };
 
     getVariableImageHeight = (position: number) => {


### PR DESCRIPTION
Instead of returning the image at index "this.props.selectedItem"
of the selected item, return the first image.