### PR TITLE
gh358 Add prop to control swipe scroll behavior

### DIFF
--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -812,6 +812,48 @@ describe('Slider', function() {
                 ).toBe(false);
             });
 
+            it('should not call setPosition if preventMovementUntilSwipeScrollTolerance is true and the tolerance has not been reached', () => {
+                renderDefaultComponent({ swipeScrollTolerance: 10, preventMovementUntilSwipeScrollTolerance: true });
+                componentInstance.setPosition = jest.fn();
+
+                expect(
+                    componentInstance.onSwipeMove({
+                        x: 5,
+                        y: 10,
+                    })
+                ).toBe(false);
+
+                expect(componentInstance.setPosition).not.toHaveBeenCalled();
+            });
+
+            it('should call setPosition if preventMovementUntilSwipeScrollTolerance is true and the tolerance has been reached', () => {
+                renderDefaultComponent({ swipeScrollTolerance: 10, preventMovementUntilSwipeScrollTolerance: true });
+                componentInstance.setPosition = jest.fn();
+
+                expect(
+                    componentInstance.onSwipeMove({
+                        x: 30,
+                        y: 10,
+                    })
+                ).toBe(true);
+
+                expect(componentInstance.setPosition).toHaveBeenCalled();
+            });
+
+            it('should still call setPosition if preventMovementUntilSwipeScrollTolerance is false and the tolerance has not been reached', () => {
+                renderDefaultComponent({ swipeScrollTolerance: 10, preventMovementUntilSwipeScrollTolerance: false });
+                componentInstance.setPosition = jest.fn();
+
+                expect(
+                    componentInstance.onSwipeMove({
+                        x: 5,
+                        y: 10,
+                    })
+                ).toBe(false);
+
+                expect(componentInstance.setPosition).toHaveBeenCalled();
+            });
+
             it('should call onSwipeMove callback', () => {
                 var onSwipeMoveFunction = jest.fn();
                 renderDefaultComponent({ onSwipeMove: onSwipeMoveFunction });

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -37,6 +37,7 @@ export interface Props {
     onSwipeStart: (event: React.TouchEvent) => void;
     onSwipeEnd: (event: React.TouchEvent) => void;
     onSwipeMove: (event: React.TouchEvent) => boolean;
+    preventMovementUntilSwipeScrollTolerance: boolean;
     renderArrowPrev: (clickHandler: () => void, hasPrev: boolean, label: string) => React.ReactNode;
     renderArrowNext: (clickHandler: () => void, hasNext: boolean, label: string) => React.ReactNode;
     renderIndicator: (
@@ -99,6 +100,7 @@ export default class Carousel extends React.Component<Props, State> {
         onSwipeStart: () => {},
         onSwipeEnd: () => {},
         onSwipeMove: () => {},
+        preventMovementUntilSwipeScrollTolerance: false,
         renderArrowPrev: (onClickHandler: () => void, hasPrev: boolean, label: string) => (
             <button type="button" aria-label={label} className={klass.ARROW_PREV(!hasPrev)} onClick={onClickHandler} />
         ),
@@ -502,7 +504,9 @@ export default class Carousel extends React.Component<Props, State> {
                 position += childrenLength * 100;
             }
         }
-        this.setPosition(position);
+        if (!this.props.preventMovementUntilSwipeScrollTolerance || hasMoved) {
+            this.setPosition(position);
+        }
 
         // allows scroll if the swipe was within the tolerance
         if (hasMoved && !this.state.cancelClick) {


### PR DESCRIPTION
The primary issue highlighted by #358 can be resolved by using swipeScrollTolerance. However the slide still moves when you are primarily scrolling vertically as described in the comments by @ovidiudinu.

This behaviour is jarring when the carousel occupies the full view height and you must scroll over it to move down the page. This PR provides a simple, opt-in way to prevent it.