### PR TITLE
358 fix glitch when swiping one way then the other

### DIFF
--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -839,6 +839,28 @@ describe('Slider', function() {
                 expect(componentInstance.setPosition).not.toHaveBeenCalled();
             });
 
+            it('should call setPosition if preventMovementUntilSwipeScrollTolerance is true and movement has already begun', () => {
+                renderDefaultComponent({ swipeScrollTolerance: 10, preventMovementUntilSwipeScrollTolerance: true });
+
+                componentInstance.setPosition = jest.fn();
+                expect(
+                    componentInstance.onSwipeMove({
+                        x: 50,
+                        y: 10,
+                    })
+                ).toBe(true);
+                expect(componentInstance.setPosition).toHaveBeenCalled();
+
+                componentInstance.setPosition = jest.fn();
+                expect(
+                    componentInstance.onSwipeMove({
+                        x: 5,
+                        y: 10,
+                    })
+                ).toBe(false);
+                expect(componentInstance.setPosition).toHaveBeenCalled();
+            });
+
             it('should call setPosition if preventMovementUntilSwipeScrollTolerance is true and the tolerance has been reached', () => {
                 renderDefaultComponent({ swipeScrollTolerance: 10, preventMovementUntilSwipeScrollTolerance: true });
                 componentInstance.setPosition = jest.fn();

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -73,6 +73,7 @@ interface State {
     itemSize: number;
     selectedItem: number;
     swiping?: boolean;
+    swipeMovementStarted: boolean;
 }
 
 export default class Carousel extends React.Component<Props, State> {
@@ -181,6 +182,7 @@ export default class Carousel extends React.Component<Props, State> {
             isMouseEntered: false,
             autoPlay: props.autoPlay,
             swiping: false,
+            swipeMovementStarted: false,
             cancelClick: false,
             itemSize: 1,
         };
@@ -467,6 +469,7 @@ export default class Carousel extends React.Component<Props, State> {
         this.setState({
             swiping: false,
             cancelClick: false,
+            swipeMovementStarted: false,
         });
         this.props.onSwipeEnd(event);
         this.autoPlay();
@@ -509,7 +512,10 @@ export default class Carousel extends React.Component<Props, State> {
                 position += childrenLength * 100;
             }
         }
-        if (!this.props.preventMovementUntilSwipeScrollTolerance || hasMoved) {
+        if (!this.props.preventMovementUntilSwipeScrollTolerance || hasMoved || this.state.swipeMovementStarted) {
+            if (!this.state.swipeMovementStarted) {
+                this.setState({ swipeMovementStarted: true });
+            }
             this.setPosition(position);
         }
 


### PR DESCRIPTION
Fixes a glitch when preventMovementUntilSwipeScrollTolerance is true and the user swipes one way and then the other.