### PR TITLE
Issue/gh 503 autoplay doesnt restart

### DIFF
--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -754,6 +754,30 @@ describe('Slider', function() {
 
             expect(componentInstance.state.selectedItem).toBe(1);
         });
+
+        it('should restart auto-play after disabling it via props', () => {
+            expect(componentInstance.state.selectedItem).toBe(0);
+
+            jest.runOnlyPendingTimers();
+
+            expect(componentInstance.state.selectedItem).toBe(1);
+
+            component.setProps({
+                autoPlay: false,
+            });
+
+            jest.runOnlyPendingTimers();
+
+            expect(componentInstance.state.selectedItem).toBe(1);
+
+            component.setProps({
+                autoPlay: true,
+            });
+
+            jest.runOnlyPendingTimers();
+
+            expect(componentInstance.state.selectedItem).toBe(2);
+        });
     });
 
     describe('Mouse enter/leave', () => {

--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -780,6 +780,51 @@ describe('Slider', function() {
         });
     });
 
+    describe('Infinite Loop and Auto Play', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+            window.addEventListener = jest.fn();
+
+            renderDefaultComponent({
+                children: [
+                    <img src="assets/1.jpeg" key="1" />,
+                    <img src="assets/2.jpeg" key="2" />,
+                    <img src="assets/3.jpeg" key="3" />,
+                ],
+                infiniteLoop: true,
+                autoPlay: true,
+            });
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        it('should automatically loop infinitely', () => {
+            expect(componentInstance.state.selectedItem).toBe(0);
+
+            jest.runOnlyPendingTimers();
+
+            expect(componentInstance.state.selectedItem).toBe(1);
+
+            jest.runOnlyPendingTimers();
+
+            expect(componentInstance.state.selectedItem).toBe(2);
+
+            jest.runOnlyPendingTimers();
+
+            expect(componentInstance.state.selectedItem).toBe(0);
+
+            jest.runOnlyPendingTimers();
+
+            expect(componentInstance.state.selectedItem).toBe(1);
+
+            jest.runOnlyPendingTimers();
+
+            expect(componentInstance.state.selectedItem).toBe(2);
+        });
+    });
+
     describe('Mouse enter/leave', () => {
         describe('onMouseEnter', () => {
             it('should set isMouseEntered to true', () => {

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -322,21 +322,18 @@ export default class Carousel extends React.Component<Props, State> {
     }
 
     autoPlay = () => {
-        if (!this.state.autoPlay || Children.count(this.props.children) <= 1) {
+        if (Children.count(this.props.children) <= 1) {
             return;
         }
 
-        if (this.timer) clearTimeout(this.timer);
+        this.clearAutoPlay();
+
         this.timer = setTimeout(() => {
             this.increment();
         }, this.props.interval);
     };
 
     clearAutoPlay = () => {
-        if (!this.state.autoPlay) {
-            return;
-        }
-
         if (this.timer) clearTimeout(this.timer);
     };
 


### PR DESCRIPTION
This is a fix for Issue #503.

Although [this](https://github.com/leandrowd/react-responsive-carousel/pull/479/files) PR exists, I preferred to take a different fix approach: I removed checks for autoPlay property on the state in the autoPlay() and clearAutoPlay() methods, because I believe these checks should occur before even invoking them, and if we got there with the wrong value - it's too late. Making these checks without throwing an error may either hide bugs or create new ones like this. I decided not to throw an error as that seems like too big of a change right now and perhaps out of scope.

Also this PR passes build and checks, and added 2 tests: one that covers the bug fix, and another one that covers the combination of infinite loop with auto play to make sure they interact correctly.