### PR TITLE
styles: Remove slide default black background

### DIFF
--- a/src/components/_carousel.scss
+++ b/src/components/_carousel.scss
@@ -196,7 +196,6 @@
         margin: 0;
         position: relative;
         text-align: center;
-        background: #000;
         // padding-bottom: 32px;
 
         img {


### PR DESCRIPTION
The class `.slide` has a default `background: #000` attribute, which for example, when using the new [next/image](https://nextjs.org/docs/api-reference/next/image) can lead to a bad user experience since there will be a black square while it's loading. Removing this would also make the slide fit in more apps, since the black background would only match applications with also dark backgrounds.

Image for example:

![Loading-example](https://user-images.githubusercontent.com/39345247/97473789-24b38e00-192a-11eb-9dd1-b106476e26b3.png)