### PR TITLE
#514 Add autoFocus prop so useKeyboardArrows works without clicking first

### DIFF
--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -784,6 +784,36 @@ describe('Slider', function() {
         });
     });
 
+    describe('Focus', () => {
+        describe('calling forceFocus', () => {
+            it('should call carousel wrapper focus', () => {
+                componentInstance.carouselWrapperRef.focus = jest.fn();
+                componentInstance.forceFocus();
+                expect(componentInstance.carouselWrapperRef.focus).toHaveBeenCalledTimes(1);
+            });
+        });
+
+        describe('AutoFocus === true', () => {
+            it('should call forceFocus on componentDidMount', () => {
+                const forceFocusSpy = jest.spyOn(Carousel.prototype, 'forceFocus');
+                renderDefaultComponent({ autoFocus: true });
+                expect(forceFocusSpy).toHaveBeenCalledTimes(1);
+                forceFocusSpy.mockReset();
+                forceFocusSpy.mockRestore();
+            });
+
+            it('should call forceFocus conditionally on componentDidUpdate', () => {
+                componentInstance.forceFocus = jest.fn();
+
+                component.setProps({ autoFocus: false });
+                expect(componentInstance.forceFocus).toHaveBeenCalledTimes(0);
+
+                component.setProps({ autoFocus: true });
+                expect(componentInstance.forceFocus).toHaveBeenCalledTimes(1);
+            });
+        });
+    });
+
     describe('Swiping', () => {
         describe('onSwipeStart', () => {
             it('should set swiping to true', () => {

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -17,6 +17,7 @@ const isKeyboardEvent = (e?: React.MouseEvent | React.KeyboardEvent): e is React
 
 export interface Props {
     axis: 'horizontal' | 'vertical';
+    autoFocus?: boolean;
     autoPlay?: boolean;
     centerMode?: boolean;
     centerSlidePercentage: number;
@@ -199,6 +200,10 @@ export default class Carousel extends React.Component<Props, State> {
             this.setupCarousel();
         }
 
+        if (!prevProps.autoFocus && this.props.autoFocus) {
+            this.forceFocus();
+        }
+
         if (prevState.swiping && !this.state.swiping) {
             // We stopped swiping, ensure we are heading to the new/current slide and not stuck
             this.resetPosition();
@@ -248,6 +253,10 @@ export default class Carousel extends React.Component<Props, State> {
 
         if (this.state.autoPlay && Children.count(this.props.children) > 1) {
             this.setupAutoPlay();
+        }
+
+        if (this.props.autoFocus) {
+            this.forceFocus();
         }
 
         this.setState(
@@ -352,6 +361,10 @@ export default class Carousel extends React.Component<Props, State> {
     startOnLeave = () => {
         this.setState({ isMouseEntered: false }, this.autoPlay);
     };
+
+    forceFocus() {
+        this.carouselWrapperRef?.focus();
+    }
 
     isFocusWithinTheCarousel = () => {
         if (!this.carouselWrapperRef) {

--- a/stories/01-basic.tsx
+++ b/stories/01-basic.tsx
@@ -34,6 +34,7 @@ const getConfigurableProps = () => ({
     swipeable: boolean('swipeable', true, tooglesGroupId),
     dynamicHeight: boolean('dynamicHeight', true, tooglesGroupId),
     emulateTouch: boolean('emulateTouch', true, tooglesGroupId),
+    autoFocus: boolean('autoFocus', false, tooglesGroupId),
     thumbWidth: number('thumbWidth', 100, {}, valuesGroupId),
     selectedItem: number('selectedItem', 0, {}, valuesGroupId),
     interval: number('interval', 3000, {}, valuesGroupId),

--- a/stories/02-advanced.tsx
+++ b/stories/02-advanced.tsx
@@ -165,7 +165,7 @@ export const withExternalControls = () => {
 };
 
 export const presentationMode = () => (
-    <Carousel showThumbs={false} showStatus={false} useKeyboardArrows className="presentation-mode">
+    <Carousel autoFocus={true} showThumbs={false} showStatus={false} useKeyboardArrows className="presentation-mode">
         <div key="content-0" className="my-slide primary">
             <h1>Presentation mode</h1>
         </div>


### PR DESCRIPTION
### Issue
When using `useKeyboardArrows` prop, the carousel must first be clicked for the key strokes to have any effect. This is confusing, especially when in presentation mode. See #514 

### Solution
Introduce a new prop `autoFocus` that will manually set the focus of the internal carousel wrapper ref element. Additionally, expose a public accessor method that can be used to forcibly set the focus from an external component.

### Notes
In order to prevent unwanted focus hijacking:
 - the `autoFocus` prop is independent of `useKeyboardArrows` prop and defaulted to false to be backward compatible
- the `autoFocus` prop can be used to restore focus via componentDidUpdate. However, it will only set focus if the prevProps.autoFocus was false and the nextProps.autoFocus is true.   