### PR TITLE
fix: dynamic height not work with a tag wrapper

### DIFF
--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -711,7 +711,9 @@ export default class Carousel extends React.Component<Props, State> {
                 }
             }
 
-            const height = item.children[0].clientHeight;
+            // try to get img first, if img not there find first display tag
+            const displayItem = slideImages[0] || item.children[0]
+            const height = displayItem.clientHeight;
             return height > 0 ? height : null;
         }
 

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -712,7 +712,7 @@ export default class Carousel extends React.Component<Props, State> {
             }
 
             // try to get img first, if img not there find first display tag
-            const displayItem = slideImages[0] || item.children[0]
+            const displayItem = slideImages[0] || item.children[0];
             const height = displayItem.clientHeight;
             return height > 0 ? height : null;
         }


### PR DESCRIPTION
If the image is wrapped by an a tag, then the dynamic height is not working, as the current logic get a tag clientHeight which is always 0.

Solution: try to get image tag first, if image not there find first first child tag.