### PR TITLE
#534: Fix Carousel swipeable with one child

### DIFF
--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -698,6 +698,15 @@ describe('Slider', function() {
             componentInstance.decrement();
             expect(componentInstance.state.selectedItem).toBe(lastItemIndex);
         });
+
+        it('should be swipeable only on Thumbs with one child', () => {
+            renderDefaultComponent({
+                children: [<img src="assets/1.jpeg" key="1" />],
+                infiniteLoop: true,
+            });
+
+            expect(component.find(Swipe).length).toBe(1);
+        });
     });
 
     describe('Auto Play', () => {

--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -699,7 +699,7 @@ describe('Slider', function() {
             expect(componentInstance.state.selectedItem).toBe(lastItemIndex);
         });
 
-        it('should be swipeable only on Thumbs with one child', () => {
+        it('should not render any Swipe component with one child', () => {
             renderDefaultComponent({
                 children: [<img src="assets/1.jpeg" key="1" />],
                 infiniteLoop: true,

--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -705,7 +705,7 @@ describe('Slider', function() {
                 infiniteLoop: true,
             });
 
-            expect(component.find(Swipe).length).toBe(1);
+            expect(component.find(Swipe).length).toBe(0);
         });
     });
 

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -803,6 +803,8 @@ export default class Carousel extends React.Component<Props, State> {
             return null;
         }
 
+        const swipeable = this.props.swipeable && Children.count(this.props.children) > 1;
+
         const isHorizontal = this.props.axis === 'horizontal';
 
         const canShowArrows = this.props.showArrows && Children.count(this.props.children) > 1;
@@ -882,7 +884,7 @@ export default class Carousel extends React.Component<Props, State> {
                 <div className={klass.CAROUSEL(true)} style={{ width: this.props.width }}>
                     {this.props.renderArrowPrev(this.onClickPrev, hasPrev, this.props.labels.leftArrow)}
                     <div className={klass.WRAPPER(true, this.props.axis)} style={containerStyles}>
-                        {this.props.swipeable ? (
+                        {swipeable ? (
                             <Swipe
                                 tagName="ul"
                                 innerRef={this.setListRef}

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -803,7 +803,7 @@ export default class Carousel extends React.Component<Props, State> {
             return null;
         }
 
-        const swipeable = this.props.swipeable && Children.count(this.props.children) > 1;
+        const isSwipeable = this.props.swipeable && Children.count(this.props.children) > 1;
 
         const isHorizontal = this.props.axis === 'horizontal';
 
@@ -884,7 +884,7 @@ export default class Carousel extends React.Component<Props, State> {
                 <div className={klass.CAROUSEL(true)} style={{ width: this.props.width }}>
                     {this.props.renderArrowPrev(this.onClickPrev, hasPrev, this.props.labels.leftArrow)}
                     <div className={klass.WRAPPER(true, this.props.axis)} style={containerStyles}>
-                        {swipeable ? (
+                        {isSwipeable ? (
                             <Swipe
                                 tagName="ul"
                                 innerRef={this.setListRef}

--- a/src/components/Thumbs.tsx
+++ b/src/components/Thumbs.tsx
@@ -265,6 +265,8 @@ export default class Thumbs extends Component<Props, State> {
             return null;
         }
 
+        const isSwipeable = Children.count(this.props.children) > 1;
+
         // show left arrow?
         const hasPrev = this.state.showArrows && this.state.firstItem > 0;
         // show right arrow
@@ -302,19 +304,29 @@ export default class Thumbs extends Component<Props, State> {
                         onClick={() => this.slideRight()}
                         aria-label={this.props.labels.leftArrow}
                     />
-                    <Swipe
-                        tagName="ul"
-                        className={klass.SLIDER(false, this.state.swiping)}
-                        onSwipeLeft={this.slideLeft}
-                        onSwipeRight={this.slideRight}
-                        onSwipeMove={this.onSwipeMove}
-                        onSwipeStart={this.onSwipeStart}
-                        onSwipeEnd={this.onSwipeEnd}
-                        style={itemListStyles}
-                        innerRef={this.setItemsListRef}
-                    >
-                        {this.renderItems()}
-                    </Swipe>
+                    {isSwipeable ? (
+                        <Swipe
+                            tagName="ul"
+                            className={klass.SLIDER(false, this.state.swiping)}
+                            onSwipeLeft={this.slideLeft}
+                            onSwipeRight={this.slideRight}
+                            onSwipeMove={this.onSwipeMove}
+                            onSwipeStart={this.onSwipeStart}
+                            onSwipeEnd={this.onSwipeEnd}
+                            style={itemListStyles}
+                            innerRef={this.setItemsListRef}
+                        >
+                            {this.renderItems()}
+                        </Swipe>
+                    ) : (
+                        <ul
+                            className={klass.SLIDER(false, this.state.swiping)}
+                            ref={(node: HTMLUListElement) => this.setItemsListRef(node)}
+                            style={itemListStyles}
+                        >
+                            {this.renderItems()}
+                        </ul>
+                    )}
                     <button
                         type="button"
                         className={klass.ARROW_NEXT(!hasNext)}


### PR DESCRIPTION
This fixes the Carousel being swipeable with the ```infiniteLoop``` flag on and with one child. The solution was to prevent the ```Swipe``` component to render when there are 1 or fewer children. (fixes #534)