### PR TITLE
 #546: Adding visual style to focused buttons

### DIFF
--- a/src/components/_carousel.scss
+++ b/src/components/_carousel.scss
@@ -9,6 +9,7 @@
     font-size: 32px;
     cursor: pointer;
 
+    &:focus,
     &:hover {
         @include opacity(1);
     }


### PR DESCRIPTION
Fix for #546

Here's a what it looked like before when the button received focus:
![Screenshot from 2021-01-31 17-27-41](https://user-images.githubusercontent.com/3979926/106401478-ea0a3780-63e9-11eb-8244-8f1baa2771d9.png)

After the change when the arrow button is focused it gets the opacity set the same as `:hover`
![Screenshot from 2021-01-31 17-32-44](https://user-images.githubusercontent.com/3979926/106401555-613fcb80-63ea-11eb-9c7c-4ea66fb27b8f.png)
