### PR TITLE
 #545: Fixing carousel focus

### DIFF
--- a/src/__tests__/__snapshots__/Carousel.tsx.snap
+++ b/src/__tests__/__snapshots__/Carousel.tsx.snap
@@ -65,7 +65,6 @@ Array [
 exports[`Slider Snapshots center mode 1`] = `
 <div
   className="carousel-root"
-  tabIndex={0}
 >
   <div
     className="carousel carousel-slider"
@@ -447,7 +446,6 @@ exports[`Slider Snapshots center mode 1`] = `
 exports[`Slider Snapshots custom class name 1`] = `
 <div
   className="carousel-root my-custom-carousel"
-  tabIndex={0}
 >
   <div
     className="carousel carousel-slider"
@@ -794,7 +792,6 @@ exports[`Slider Snapshots custom class name 1`] = `
 exports[`Slider Snapshots custom width 1`] = `
 <div
   className="carousel-root"
-  tabIndex={0}
 >
   <div
     className="carousel carousel-slider"
@@ -1141,7 +1138,6 @@ exports[`Slider Snapshots custom width 1`] = `
 exports[`Slider Snapshots default 1`] = `
 <div
   className="carousel-root"
-  tabIndex={0}
 >
   <div
     className="carousel carousel-slider"
@@ -1488,7 +1484,6 @@ exports[`Slider Snapshots default 1`] = `
 exports[`Slider Snapshots infinite loop 1`] = `
 <div
   className="carousel-root"
-  tabIndex={0}
 >
   <div
     className="carousel carousel-slider"
@@ -1851,7 +1846,6 @@ exports[`Slider Snapshots infinite loop 1`] = `
 exports[`Slider Snapshots no arrows 1`] = `
 <div
   className="carousel-root"
-  tabIndex={0}
 >
   <div
     className="carousel carousel-slider"
@@ -2200,7 +2194,6 @@ exports[`Slider Snapshots no children at mount 1`] = `null`;
 exports[`Slider Snapshots no indicators 1`] = `
 <div
   className="carousel-root"
-  tabIndex={0}
 >
   <div
     className="carousel carousel-slider"
@@ -2480,7 +2473,6 @@ exports[`Slider Snapshots no indicators 1`] = `
 exports[`Slider Snapshots no indicators 2`] = `
 <div
   className="carousel-root"
-  tabIndex={0}
 >
   <div
     className="carousel carousel-slider"
@@ -2822,7 +2814,6 @@ exports[`Slider Snapshots no indicators 2`] = `
 exports[`Slider Snapshots no thumbs 1`] = `
 <div
   className="carousel-root"
-  tabIndex={0}
 >
   <div
     className="carousel carousel-slider"
@@ -3007,7 +2998,6 @@ exports[`Slider Snapshots no thumbs 1`] = `
 exports[`Slider Snapshots swipeable false 1`] = `
 <div
   className="carousel-root"
-  tabIndex={0}
 >
   <div
     className="carousel carousel-slider"
@@ -3351,7 +3341,6 @@ exports[`Slider Snapshots swipeable false 1`] = `
 exports[`Slider Snapshots vertical axis 1`] = `
 <div
   className="carousel-root"
-  tabIndex={0}
 >
   <div
     className="carousel carousel-slider"

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -878,7 +878,7 @@ export default class Carousel extends React.Component<Props, State> {
             containerStyles.height = this.state.itemSize;
         }
         return (
-            <div className={klass.ROOT(this.props.className)} ref={this.setCarouselWrapperRef} tabIndex={0}>
+            <div className={klass.ROOT(this.props.className)} ref={this.setCarouselWrapperRef}>
                 <div className={klass.CAROUSEL(true)} style={{ width: this.props.width }}>
                     {this.props.renderArrowPrev(this.onClickPrev, hasPrev, this.props.labels.leftArrow)}
                     <div className={klass.WRAPPER(true, this.props.axis)} style={containerStyles}>


### PR DESCRIPTION
Fix for #545 

The tabindex was removed from the `.carousel-root`. Most of the snapshot files for testing picked up this change so there's some extra noise in the diffs.