### PR TITLE
#517: Fix emulated touch never changing slide

### DIFF
--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -965,18 +965,20 @@ describe('Slider', function() {
                     emulateTouch: true,
                 });
 
-                const initialIndex = componentInstance.state.selectedItem;
+                let currentIndex = componentInstance.state.selectedItem;
                 const items = componentInstance.props.children;
 
                 componentInstance.onSwipeForward();
-                componentInstance.handleClickItem(initialIndex, items[initialIndex]);
+                componentInstance.handleClickItem(currentIndex, items[currentIndex]);
+                ++currentIndex;
 
-                expect(componentInstance.state.selectedItem).toEqual(initialIndex + 1);
+                expect(componentInstance.state.selectedItem).toEqual(currentIndex);
 
                 componentInstance.onSwipeBackwards();
-                componentInstance.handleClickItem(initialIndex + 1, items[initialIndex + 1]);
+                componentInstance.handleClickItem(currentIndex, items[currentIndex]);
+                --currentIndex;
 
-                expect(componentInstance.state.selectedItem).toEqual(initialIndex);
+                expect(componentInstance.state.selectedItem).toEqual(currentIndex);
             });
         });
     });

--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -958,6 +958,27 @@ describe('Slider', function() {
                 expect(swipeProps.onSwipeDown).toBe(componentInstance.onSwipeForward);
             });
         });
+
+        describe('emulateTouch', () => {
+            it('should cancel click when swipe forward and backwards with emulated touch', () => {
+                renderDefaultComponent({
+                    emulateTouch: true,
+                });
+
+                const initialIndex = componentInstance.state.selectedItem;
+                const items = componentInstance.props.children;
+
+                componentInstance.onSwipeForward();
+                componentInstance.handleClickItem(initialIndex, items[initialIndex]);
+
+                expect(componentInstance.state.selectedItem).toEqual(initialIndex + 1);
+
+                componentInstance.onSwipeBackwards();
+                componentInstance.handleClickItem(initialIndex + 1, items[initialIndex + 1]);
+
+                expect(componentInstance.state.selectedItem).toEqual(initialIndex);
+            });
+        });
     });
 
     describe('center mode', () => {

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -665,10 +665,18 @@ export default class Carousel extends React.Component<Props, State> {
 
     onSwipeForward = () => {
         this.increment(1, true);
+
+        if (this.props.emulateTouch) {
+            this.setState({ cancelClick: true });
+        }
     };
 
     onSwipeBackwards = () => {
         this.decrement(1, true);
+
+        if (this.props.emulateTouch) {
+            this.setState({ cancelClick: true });
+        }
     };
 
     changeItem = (newIndex: number) => (e: React.MouseEvent | React.KeyboardEvent) => {

--- a/src/components/_carousel.scss
+++ b/src/components/_carousel.scss
@@ -203,10 +203,6 @@
             width: 100%;
             vertical-align: top;
             border: 0;
-            -webkit-user-select: none;
-            -moz-user-select: none;
-            -ms-user-select: none;
-            user-select: none;
         }
 
         iframe {

--- a/src/components/_carousel.scss
+++ b/src/components/_carousel.scss
@@ -203,6 +203,10 @@
             width: 100%;
             vertical-align: top;
             border: 0;
+            -webkit-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
         }
 
         iframe {


### PR DESCRIPTION
Fixes #517.
## The cause
The ```handleClickItem``` is called when the mouse click is released on the end of a swipe, which sets the ```selectedItem``` state to the current slide and makes it impossible to change the slide through a swipe on non-touch devices since these devices will always trigger a click event while swiping.
## Solution
It sets the ```cancelClick``` state to false on ```onSwipeForward``` and ```onSwipeBackwards```, which prevents the ```handleClickItem``` to set the ```selectedItem``` state to the swiped item.