### PR TITLE
#525: Fix indicator click not resetting autoplay

### DIFF
--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -787,6 +787,21 @@ describe('Slider', function() {
 
             expect(componentInstance.state.selectedItem).toBe(2);
         });
+
+        it('should reset when changing the slide through indicator', () => {
+            renderDefaultComponent({ interval: 3000, autoPlay: true });
+            jest.advanceTimersByTime(2000);
+
+            expect(componentInstance.state.selectedItem).toBe(0);
+
+            const changeToSecondItem = componentInstance.changeItem(1);
+            // it only runs with an event
+            changeToSecondItem(new MouseEvent('click'));
+
+            jest.advanceTimersByTime(1000);
+
+            expect(componentInstance.state.selectedItem).toBe(1);
+        });
     });
 
     describe('Infinite Loop and Auto Play', () => {

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -462,9 +462,7 @@ export default class Carousel extends React.Component<Props, State> {
     handleClickThumb = (index: number, item: React.ReactNode) => {
         this.props.onClickThumb(index, item);
 
-        this.selectItem({
-            selectedItem: index,
-        });
+        this.moveTo(index);
     };
 
     onSwipeStart = (event: React.TouchEvent) => {
@@ -684,13 +682,7 @@ export default class Carousel extends React.Component<Props, State> {
 
     changeItem = (newIndex: number) => (e: React.MouseEvent | React.KeyboardEvent) => {
         if (!isKeyboardEvent(e) || e.key === 'Enter') {
-            this.selectItem({
-                selectedItem: newIndex,
-            });
-
-            if (this.state.autoPlay) {
-                this.resetAutoPlay();
-            }
+            this.moveTo(newIndex);
         }
     };
 

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -687,6 +687,10 @@ export default class Carousel extends React.Component<Props, State> {
             this.selectItem({
                 selectedItem: newIndex,
             });
+
+            if (this.state.autoPlay) {
+                this.resetAutoPlay();
+            }
         }
     };
 


### PR DESCRIPTION
Fixes #525.

In the issue, there's a workaround by calling the ```resetAutoPlay``` with the ```Carousel``` ref on the ```onChange``` callback, but it can simply be solved by resetting the autoplay on the ```changeItem``` method, which also prevents an unnecessary reset since the ```onChange``` callback it's not only called by the indicators.
## Before
![The image changes right after changing the slide through the indicators](https://user-images.githubusercontent.com/43624243/107977576-17361880-6f9a-11eb-8f02-1eb376419354.gif)

## After
![The image don't autoplay right after a click on some indicator](https://user-images.githubusercontent.com/43624243/107977589-1f8e5380-6f9a-11eb-8654-1b9415bd8a2a.gif)
