### PR TITLE
#570: making the thumbnail height auto

### DIFF
--- a/src/components/_carousel.scss
+++ b/src/components/_carousel.scss
@@ -62,6 +62,7 @@
 
     img {
         width: 100%;
+        height: auto;
         display: inline-block;
         pointer-events: none;
     }


### PR DESCRIPTION
making the thumbnail height auto to let the images have width and height attributes. It will reduce cumulative layout shift.