### PR TITLE
#563: Ignore falsy children

### DIFF
--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -1172,6 +1172,32 @@ describe('Slider', function() {
         });
     });
 
+    describe('ignore falsy children', () => {
+        const baseChildrenWithFalsy = [...baseChildren, null, false, ''] as React.ReactChild[];
+
+        it('should not create slides for falsy children', () => {
+            renderDefaultComponent({
+                children: baseChildrenWithFalsy,
+            });
+            expect(component.find('.slide').length).toBe(baseChildren.length);
+        });
+
+        it('should not display thumbnail for falsy children', () => {
+            renderDefaultComponent({
+                children: baseChildrenWithFalsy,
+            });
+            expect(component.find('.thumb').length).toBe(baseChildren.length);
+        });
+
+        it('should not display dot for falsy children', () => {
+            renderDefaultComponent({
+                children: baseChildrenWithFalsy,
+                showThumbs: false,
+            });
+            expect(component.find('.dot').length).toBe(baseChildren.length);
+        });
+    });
+
     describe('Snapshots', () => {
         it('default', () => {
             expect(renderForSnapshot({}, baseChildren)).toMatchSnapshot();


### PR DESCRIPTION
Implementation of the proposition made in #563 

Since you don't use React hooks yet, I used the old `componentWillReceiveProps` method to memoize the filtered list of children.
Tell me if you prefer another method.