### PR TITLE
#562: Fix carousel autoplaying after swipe

### DIFF
--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -963,7 +963,15 @@ describe('Slider', function() {
                 componentInstance.onSwipeEnd();
                 expect(componentInstance.state.swiping).toBe(false);
             });
-            it('should start autoplay again', () => {
+
+            it('should not start autoplay again', () => {
+                componentInstance.autoPlay = jest.fn();
+                componentInstance.onSwipeEnd();
+                expect(componentInstance.autoPlay).toHaveBeenCalledTimes(0);
+            });
+
+            it('should start autoplay again when autoplay is true', () => {
+                renderDefaultComponent({ autoPlay: true });
                 componentInstance.autoPlay = jest.fn();
                 componentInstance.onSwipeEnd();
                 expect(componentInstance.autoPlay).toHaveBeenCalledTimes(1);

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -444,7 +444,10 @@ export default class Carousel extends React.Component<CarouselProps, CarouselSta
             swipeMovementStarted: false,
         });
         this.props.onSwipeEnd(event);
-        this.autoPlay();
+
+        if (this.state.autoPlay) {
+            this.autoPlay();
+        }
     };
 
     onSwipeMove = (delta: { x: number; y: number }, event: React.TouchEvent) => {


### PR DESCRIPTION
Fixes #562, Fixes #582, Fixes #581.

The PR #511 doesn't let the carousel check if the `autoplay` state is set to true on the `autoPlay` method without adding somewhere else to check it when needed, causing the autoplay to start on the `onSwipeEnd` method.
https://github.com/leandrowd/react-responsive-carousel/blob/ccd641d57e28b71105d22b94644c9dd91dcff13e/src/components/Carousel.tsx#L476-L483