### PR TITLE
Improving constrast on control dots

### DIFF
--- a/src/components/_carousel.scss
+++ b/src/components/_carousel.scss
@@ -246,7 +246,7 @@
         .dot {
             @include transition(opacity, 0.25s, ease-in);
             @include opacity(0.3);
-            box-shadow: 1px 1px 2px rgba(#000, 0.9);
+            box-shadow: 0px 0px 0px 2px #000;
             background: #fff;
             border-radius: 50%;
             width: 8px;


### PR DESCRIPTION
Using box-shadow to create a black border around the control dots to improve the visibility on white backgrounds.