### PR TITLE
#460: Allow customization of which elements are filtered for thumbnails

### DIFF
--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -170,6 +170,58 @@ describe('Slider', function() {
                     ).toMatchSnapshot();
                 });
 
+                it('renderThumbs should return a list of some customized elements extracted from the children', () => {
+                    expect(
+                        componentInstance.props.renderThumbs!(
+                            [
+                                <li>
+                                    <span>
+                                        <img src="assets/1.jpeg" key="1" />
+                                    </span>
+                                    <p>Legend 1</p>
+                                </li>,
+                                <li>
+                                    <span>
+                                        <img src="assets/2.jpeg" key="2" />
+                                    </span>
+                                    <p>Legend 2</p>
+                                </li>,
+                                <li>
+                                    <span>
+                                        <img src="assets/3.jpeg" key="3" />
+                                    </span>
+                                    <p>Legend 3</p>
+                                </li>,
+                                <li>
+                                    <span>
+                                        <img src="assets/4.jpeg" key="4" />
+                                    </span>
+                                    <p>Legend 4</p>
+                                </li>,
+                                <li>
+                                    <span>
+                                        <img src="assets/5.jpeg" key="5" />
+                                    </span>
+                                    <p>Legend 5</p>
+                                </li>,
+                                <li>
+                                    <span>
+                                        <img src="assets/6.jpeg" key="6" />
+                                    </span>
+                                    <p>Legend 6</p>
+                                </li>,
+                                <li>
+                                    <span>
+                                        <img src="assets/7.jpeg" key="7" />
+                                    </span>
+                                    <p>Legend 7</p>
+                                </li>,
+                            ],
+                            (itemType: any) => itemType === 'span'
+                        )
+                    ).toMatchSnapshot();
+                });
+
                 it('statusFormatter should return a string', () => {
                     expect(componentInstance.props.statusFormatter!(1, 3)).toEqual('1 of 3');
                 });

--- a/src/__tests__/__snapshots__/Carousel.tsx.snap
+++ b/src/__tests__/__snapshots__/Carousel.tsx.snap
@@ -36,6 +36,46 @@ exports[`Slider Basics Default Props methods renderItem should pass through the 
 </div>
 `;
 
+exports[`Slider Basics Default Props methods renderThumbs should return a list of some customized elements extracted from the children 1`] = `
+Array [
+  <span>
+    <img
+      src="assets/1.jpeg"
+    />
+  </span>,
+  <span>
+    <img
+      src="assets/2.jpeg"
+    />
+  </span>,
+  <span>
+    <img
+      src="assets/3.jpeg"
+    />
+  </span>,
+  <span>
+    <img
+      src="assets/4.jpeg"
+    />
+  </span>,
+  <span>
+    <img
+      src="assets/5.jpeg"
+    />
+  </span>,
+  <span>
+    <img
+      src="assets/6.jpeg"
+    />
+  </span>,
+  <span>
+    <img
+      src="assets/7.jpeg"
+    />
+  </span>,
+]
+`;
+
 exports[`Slider Basics Default Props methods renderThumbs should return a list of images extracted from the children 1`] = `
 Array [
   <img

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -6,7 +6,7 @@ import Thumbs from '../Thumbs';
 import getDocument from '../../shims/document';
 import getWindow from '../../shims/window';
 import { noop, defaultStatusFormatter, isKeyboardEvent } from './utils';
-import { AnimationHandler, CarouselProps, CarouselState } from './types';
+import { AnimationHandler, CarouselProps, CarouselState, ThumbElementTypeMatcher } from './types';
 import {
     slideAnimationHandler,
     slideSwipeAnimationHandler,
@@ -69,15 +69,18 @@ export default class Carousel extends React.Component<CarouselProps, CarouselSta
         renderItem: (item: React.ReactNode) => {
             return item;
         },
-        renderThumbs: (children: React.ReactChild[]) => {
+        renderThumbs: (
+            children: React.ReactChild[],
+            typeMatcher: ThumbElementTypeMatcher = (itemType) => itemType === 'img'
+        ) => {
             const images = Children.map<React.ReactChild | undefined, React.ReactChild>(children, (item) => {
                 let img: React.ReactChild | undefined = item;
 
                 // if the item is not an image, try to find the first image in the item's children.
-                if ((item as React.ReactElement<{ children: React.ReactChild[] }>).type !== 'img') {
-                    img = (Children.toArray((item as React.ReactElement).props.children) as React.ReactChild[]).find(
-                        (children) => (children as React.ReactElement).type === 'img'
-                    );
+                if (!typeMatcher((item as React.ReactElement<{ children: React.ReactChild[] }>).type)) {
+                    img = (Children.toArray(
+                        (item as React.ReactElement).props.children
+                    ) as React.ReactChild[]).find((children) => typeMatcher((children as React.ReactElement).type));
                 }
 
                 if (!img) {
@@ -106,6 +109,7 @@ export default class Carousel extends React.Component<CarouselProps, CarouselSta
         stopOnHover: true,
         swipeScrollTolerance: 5,
         swipeable: true,
+        thumbElementTypeMatcher: undefined,
         transitionTime: 350,
         verticalSwipe: 'standard',
         width: '100%',
@@ -687,7 +691,7 @@ export default class Carousel extends React.Component<CarouselProps, CarouselSta
                 thumbWidth={this.props.thumbWidth}
                 labels={this.props.labels}
             >
-                {this.props.renderThumbs(this.props.children)}
+                {this.props.renderThumbs(this.props.children, this.props.thumbElementTypeMatcher)}
             </Thumbs>
         );
     }

--- a/src/components/Carousel/types.ts
+++ b/src/components/Carousel/types.ts
@@ -19,6 +19,8 @@ export type SwipeAnimationHandler = (
 
 export type StopSwipingHandler = (props: CarouselProps, state: CarouselState) => AnimationHandlerResponse;
 
+export type ThumbElementTypeMatcher = (itemType: any) => boolean;
+
 export interface CarouselProps {
     axis: 'horizontal' | 'vertical';
     autoFocus?: boolean;
@@ -52,7 +54,10 @@ export interface CarouselProps {
         label: string
     ) => React.ReactNode;
     renderItem: (item: React.ReactNode, options?: { isSelected: boolean; isPrevious: boolean }) => React.ReactNode;
-    renderThumbs: (children: React.ReactChild[]) => React.ReactChild[];
+    renderThumbs: (
+        children: React.ReactChild[],
+        typeMatcher: undefined | ThumbElementTypeMatcher
+    ) => React.ReactChild[];
     selectedItem: number;
     showArrows: boolean;
     showStatus: boolean;
@@ -63,6 +68,7 @@ export interface CarouselProps {
     swipeable: boolean;
     swipeScrollTolerance: number;
     thumbWidth?: number;
+    thumbElementTypeMatcher: undefined | ThumbElementTypeMatcher;
     transitionTime: number;
     useKeyboardArrows?: boolean;
     verticalSwipe: 'natural' | 'standard';


### PR DESCRIPTION
This fixes #460 by providing a way to filter by more than just `img` elements to use as thumbnails.

Example use case: `StaticImage` as provided by `gatsby-plugin-image` produces a structure similar to:
```
<div data-gatsby-image-wrapper="" class="gatsby-image-wrapper gatsby-image-wrapper-constrained">
  <div style="max-width: 630px; display: block;">
    <img ...>
  </div>
  <picture>
    <source type="image/webp" srcset=...>
    <img data-main-image=...>
  </picture>
  <noscript></noscript>
</div>
```
Instead of attempting to guess where the thumbnail image may reside (by picking the first `img` element at some depth, for example), we can simply let the author determine the element to use for the thumbnail. In the `StaticImage` case, we can use the entire structure by using a matcher like:
```
<Carousel thumbElementTypeMatcher={(itemType) => itemType.displayName === 'StaticImage'}>
  <StaticImage src="myimage.png" />
</Carousel>
```