### PR TITLE
export Carousel Props

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { default as Carousel } from './components/Carousel';
+export { CarouselProps } from './components/Carousel/types';
 export { default as Thumbs } from './components/Thumbs';


### PR DESCRIPTION
It would be beneficial to have direct access to the `CarouselProps` (for example for extending the Carousel Props interface for a custom component built on top of the Carousel).

Very small change here so I hope it can be accepted. Will fork and use my own while waiting for feedback on this.