### PR TITLE
fix: carousel autoplaying after swipe

### DIFF
--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -910,12 +910,6 @@ describe('Slider', function() {
                 expect(componentInstance.state.swiping).toBe(true);
             });
 
-            it('should stop autoplay', () => {
-                componentInstance.clearAutoPlay = jest.fn();
-                componentInstance.onSwipeStart();
-                expect(componentInstance.clearAutoPlay).toHaveBeenCalledTimes(1);
-            });
-
             it('should call onSwipeStart callback', () => {
                 var onSwipeStartFunction = jest.fn();
                 renderDefaultComponent({ onSwipeStart: onSwipeStartFunction });
@@ -970,6 +964,12 @@ describe('Slider', function() {
             it('should set swiping to false', () => {
                 componentInstance.onSwipeEnd();
                 expect(componentInstance.state.swiping).toBe(false);
+            });
+
+            it('should stop autoplay', () => {
+                componentInstance.clearAutoPlay = jest.fn();
+                componentInstance.onSwipeStart();
+                expect(componentInstance.clearAutoPlay).toHaveBeenCalledTimes(1);
             });
 
             it('should not start autoplay again', () => {

--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -968,7 +968,7 @@ describe('Slider', function() {
 
             it('should stop autoplay', () => {
                 componentInstance.clearAutoPlay = jest.fn();
-                componentInstance.onSwipeStart();
+                componentInstance.onSwipeEnd();
                 expect(componentInstance.clearAutoPlay).toHaveBeenCalledTimes(1);
             });
 

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -449,7 +449,10 @@ export default class Carousel extends React.Component<CarouselProps, CarouselSta
         });
         this.props.onSwipeEnd(event);
 
+        this.clearAutoPlay();
+        console.log('i think state is false');
         if (this.state.autoPlay) {
+            console.log('i think state is true');
             this.autoPlay();
         }
     };

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -450,9 +450,8 @@ export default class Carousel extends React.Component<CarouselProps, CarouselSta
         this.props.onSwipeEnd(event);
 
         this.clearAutoPlay();
-        console.log('i think state is false');
+
         if (this.state.autoPlay) {
-            console.log('i think state is true');
             this.autoPlay();
         }
     };

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -438,7 +438,6 @@ export default class Carousel extends React.Component<CarouselProps, CarouselSta
             swiping: true,
         });
         this.props.onSwipeStart(event);
-        this.clearAutoPlay();
     };
 
     onSwipeEnd = (event: React.TouchEvent) => {


### PR DESCRIPTION
Addressing this finally, I think. This builds on the fix from @renancleyson-dev in PR #583 and @SUCHiDEV in PR #597 and as mentioned in Issue #621.

I think those fixes were correct, except we additionally need to move the `clearAutoPlay` call from `onSwipeStart` to `onSwipeEnd`.

This fix is working flawlessly in my local environment and on an actual phone, not simulated. I can also toggle `autoPlay` on and off and it behaves as expected in each instance.