### PR TITLE
Prevent anchor tags from being accessed when swiping

### DIFF
--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -630,6 +630,10 @@ export default class Carousel extends React.Component<CarouselProps, CarouselSta
                 style = { ...style, minWidth: this.props.centerSlidePercentage + '%' };
             }
 
+            if (this.state.swiping && this.state.swipeMovementStarted) {
+                style = { ...style, pointerEvents: 'none' };
+            }
+
             const slideProps = {
                 ref: (e: HTMLLIElement) => this.setItemsRef(e, index),
                 key: 'itemKey' + index + (isClone ? 'clone' : ''),


### PR DESCRIPTION
This addition prevents the link that is wrapping the image from working while you are swiping the carousel. The link will work as normal when not swiping.