### PR TITLE
Fix UNSAFE_componentWillReceiveProps warning in Thumbs

### DIFF
--- a/src/components/Thumbs.tsx
+++ b/src/components/Thumbs.tsx
@@ -70,16 +70,14 @@ export default class Thumbs extends Component<Props, State> {
         this.setupThumbs();
     }
 
-    UNSAFE_componentWillReceiveProps(props: Props) {
-        if (props.selectedItem !== this.state.selectedItem) {
+    componentDidUpdate(prevProps: Props) {
+        if (this.props.selectedItem !== this.state.selectedItem) {
             this.setState({
-                selectedItem: props.selectedItem,
-                firstItem: this.getFirstItem(props.selectedItem),
+                selectedItem: this.props.selectedItem,
+                firstItem: this.getFirstItem(this.props.selectedItem),
             });
         }
-    }
 
-    componentDidUpdate(prevProps: Props) {
         if (this.props.children === prevProps.children) {
             return;
         }


### PR DESCRIPTION
This fixes https://github.com/leandrowd/react-responsive-carousel/issues/454 by moving some logic from `UNSAFE_componentWillReceiveProps` to `componentDidUpdate`