### PR TITLE
allow scroll of multiple items

### DIFF
--- a/src/CSSTranslate.ts
+++ b/src/CSSTranslate.ts
@@ -1,5 +1,6 @@
-export default (position: number, metric: 'px' | '%', axis: 'horizontal' | 'vertical') => {
-    const positionPercent = position === 0 ? position : position + metric;
+export default (position: number, metric: 'px' | '%', axis: 'horizontal' | 'vertical', totalItems = 1) => {
+    const positionPercent = position === 0 ? position : `${position / totalItems}${metric}`;
+
     const positionCss = axis === 'horizontal' ? [positionPercent, 0, 0] : [0, positionPercent, 0];
     const transitionProp = 'translate3d';
 

--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -184,7 +184,7 @@ describe('Slider', function() {
 
             Object.entries(props).forEach((key, value) => {
                 it(`should have ${key} as ${value}`, () => {
-                    expect(component.state('selectedItem')).toBe(0);
+                    expect(component.state('selectedItems')).toBe([0]);
                     expect(component.state('hasMount')).toBe(false);
                 });
             });
@@ -497,7 +497,7 @@ describe('Slider', function() {
 
         it('should call selectItem sending selectedItem as 1', () => {
             expect(componentInstance.selectItem.mock.calls[0][0]).toEqual({
-                selectedItem: 1,
+                selectedItems: [1],
             });
         });
     });

--- a/src/__tests__/animations.ts
+++ b/src/__tests__/animations.ts
@@ -18,8 +18,10 @@ describe('Default Animations', () => {
         props = Carousel.defaultProps;
         state = {
             initialized: false,
-            previousItem: 0,
+            previousItems: [0],
+            selectedItems: [1],
             selectedItem: 1,
+            centerSlidePercentage: 100,
             hasMount: false,
             isMouseEntered: false,
             autoPlay: true,

--- a/src/components/Carousel/animations.ts
+++ b/src/components/Carousel/animations.ts
@@ -10,33 +10,39 @@ import { AnimationHandler, AnimationHandlerResponse, SwipeAnimationHandler, Stop
  */
 export const slideAnimationHandler: AnimationHandler = (props, state): AnimationHandlerResponse => {
     const returnStyles: AnimationHandlerResponse = {};
-    const { selectedItem } = state;
-    const previousItem = selectedItem;
+    const { selectedItems } = state;
+    const previousItems = selectedItems;
     const lastPosition = Children.count(props.children) - 1;
-    const needClonedSlide = props.infiniteLoop && (selectedItem < 0 || selectedItem > lastPosition);
+    const needClonedSlide =
+        props.infiniteLoop && (selectedItems[0] < 0 || selectedItems[selectedItems.length - 1] > lastPosition);
 
     // Handle list position if it needs a clone
     if (needClonedSlide) {
-        if (previousItem < 0) {
+        if (previousItems[0] < 0) {
             if (props.centerMode && props.centerSlidePercentage && props.axis === 'horizontal') {
                 returnStyles.itemListStyle = setPosition(
                     -(lastPosition + 2) * props.centerSlidePercentage - (100 - props.centerSlidePercentage) / 2,
-                    props.axis
+                    props.axis,
+                    state.selectedItems.length
                 );
             } else {
-                returnStyles.itemListStyle = setPosition(-(lastPosition + 2) * 100, props.axis);
+                returnStyles.itemListStyle = setPosition(
+                    -(lastPosition + 2) * 100,
+                    props.axis,
+                    state.selectedItems.length
+                );
             }
-        } else if (previousItem > lastPosition) {
-            returnStyles.itemListStyle = setPosition(0, props.axis);
+        } else if (previousItems[previousItems.length - 1] > lastPosition) {
+            returnStyles.itemListStyle = setPosition(0, props.axis, state.selectedItems.length);
         }
 
         return returnStyles;
     }
 
-    const currentPosition = getPosition(selectedItem, props);
+    const currentPosition = getPosition(selectedItems[0], props);
 
     // if 3d is available, let's take advantage of the performance of transform
-    const transformProp = CSSTranslate(currentPosition, '%', props.axis);
+    const transformProp = CSSTranslate(currentPosition, '%', props.axis, selectedItems.length);
 
     const transitionTime = props.transitionTime + 'ms';
 
@@ -80,7 +86,7 @@ export const slideSwipeAnimationHandler: SwipeAnimationHandler = (
 
     const initialBoundry = 0;
 
-    const currentPosition = getPosition(state.selectedItem, props);
+    const currentPosition = getPosition(state.selectedItems[0], props);
     const finalBoundry = props.infiniteLoop
         ? getPosition(childrenLength - 1, props) - 100
         : getPosition(childrenLength - 1, props);
@@ -104,9 +110,9 @@ export const slideSwipeAnimationHandler: SwipeAnimationHandler = (
     if (props.infiniteLoop && hasMoved) {
         // When allowing infinite loop, if we slide left from position 0 we reveal the cloned last slide that appears before it
         // if we slide even further we need to jump to other side so it can continue - and vice versa for the last slide
-        if (state.selectedItem === 0 && position > -100) {
+        if (state.selectedItems[0] === 0 && position > -100) {
             position -= childrenLength * 100;
-        } else if (state.selectedItem === childrenLength - 1 && position < -childrenLength * 100) {
+        } else if (state.selectedItems[0] === childrenLength - 1 && position < -childrenLength * 100) {
             position += childrenLength * 100;
         }
     }
@@ -116,7 +122,7 @@ export const slideSwipeAnimationHandler: SwipeAnimationHandler = (
             setState({ swipeMovementStarted: true });
         }
 
-        returnStyles.itemListStyle = setPosition(position, props.axis);
+        returnStyles.itemListStyle = setPosition(position, props.axis, state.selectedItems.length);
     }
 
     //allows scroll if the swipe was within the tolerance
@@ -134,8 +140,8 @@ export const slideSwipeAnimationHandler: SwipeAnimationHandler = (
  * @param state
  */
 export const slideStopSwipingHandler: StopSwipingHandler = (props, state): AnimationHandlerResponse => {
-    const currentPosition = getPosition(state.selectedItem, props);
-    const itemListStyle = setPosition(currentPosition, props.axis);
+    const currentPosition = getPosition(state.selectedItems[0], props);
+    const itemListStyle = setPosition(currentPosition, props.axis, state.selectedItems.length);
 
     return {
         itemListStyle,

--- a/src/components/Carousel/types.ts
+++ b/src/components/Carousel/types.ts
@@ -37,6 +37,8 @@ export interface CarouselProps {
         rightArrow: string;
         item: string;
     };
+    numItemsDisplayed: number;
+    numItemsToScroll: number;
     onClickItem: (index: number, item: React.ReactNode) => void;
     onClickThumb: (index: number, item: React.ReactNode) => void;
     onChange: (index: number, item: React.ReactNode) => void;
@@ -55,6 +57,7 @@ export interface CarouselProps {
     renderItem: (item: React.ReactNode, options?: { isSelected: boolean; isPrevious: boolean }) => React.ReactNode;
     renderThumbs: (children: React.ReactChild[]) => React.ReactChild[];
     selectedItem: number;
+    selectedItems: number[];
     showArrows: boolean;
     showStatus: boolean;
     showIndicators: boolean;
@@ -76,11 +79,13 @@ export interface CarouselProps {
 export interface CarouselState {
     autoPlay?: boolean;
     cancelClick: boolean;
+    centerSlidePercentage: number;
     hasMount: boolean;
     initialized: boolean;
     isMouseEntered: boolean;
     itemSize: number;
-    previousItem: number;
+    previousItems: number[];
+    selectedItems: number[];
     selectedItem: number;
     swiping?: boolean;
     swipeMovementStarted: boolean;

--- a/src/components/Carousel/utils.ts
+++ b/src/components/Carousel/utils.ts
@@ -45,11 +45,11 @@ export const getPosition = (index: number, props: CarouselProps): number => {
  * @param position
  * @param forceReflow
  */
-export const setPosition = (position: number, axis: 'horizontal' | 'vertical'): React.CSSProperties => {
+export const setPosition = (position: number, axis: 'horizontal' | 'vertical', totalItems = 1): React.CSSProperties => {
     const style = {};
     ['WebkitTransform', 'MozTransform', 'MsTransform', 'OTransform', 'transform', 'msTransform'].forEach((prop) => {
         // @ts-ignore
-        style[prop] = CSSTranslate(position, '%', axis);
+        style[prop] = CSSTranslate(position, '%', axis, totalItems);
     });
 
     return style;


### PR DESCRIPTION
## Objective
As a user I want to be able to scroll through multiple items at a time. This can currently sort of be hacked with `centerSlidePercentage` when there are multiples of 3, however, one element is still only considered the selected element, and this doesn't work for multiples of 2.

Relates to issues:
- https://github.com/leandrowd/react-responsive-carousel/issues/339
- https://github.com/leandrowd/react-responsive-carousel/issues/184

This seems to work as is, but some tests are failing and I am just curious to get a general critique of this strategy @leandrowd 