### PR TITLE
Fix for  #703. Also improved typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ renderItem: (item: React.ReactNode, options?: { isSelected: boolean }) => React.
 By default, thumbs are generated extracting the images in each slide. If you don't have images on your slides or if you prefer a different thumbnail, use the method `renderThumbs` to return a new list of images to be used as thumbs.
 
 ```
-renderThumbs: (children: React.ReactChild[]) => React.ReactChild[]
+renderThumbs: (children: React.ReactNode) => React.ReactNode
 ```
 
 #### Arrows

--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -189,6 +189,15 @@ describe('Slider', function() {
                 });
             });
         });
+
+        describe('Different child types', () => {
+            it('should handle single element', () => {
+                <Carousel>{baseChildren[0]}</Carousel>;
+            });
+            it('should handle JSX.Element[]', () => {
+                <Carousel>{baseChildren}</Carousel>;
+            });
+        });
     });
 
     describe('componentDidMount', () => {

--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -43,8 +43,8 @@ describe('Slider', function() {
 
         componentInstance = component.instance();
 
-        totalChildren = children && children.length ? React.Children.count(componentInstance.props.children) : 0;
-        lastItemIndex = totalChildren - 1;
+        totalChildren = children ? React.Children.count(componentInstance.props.children) : 0;
+        lastItemIndex = Math.max(totalChildren - 1, 0);
     };
 
     const baseChildren = [

--- a/src/__tests__/Carousel.tsx
+++ b/src/__tests__/Carousel.tsx
@@ -3,8 +3,7 @@ import ReactDOM from 'react-dom';
 import { shallow, mount, ReactWrapper } from 'enzyme';
 import renderer from 'react-test-renderer';
 import * as index from '../index';
-// @ts-ignore
-import Swipe, { ReactEasySwipeProps } from 'react-easy-swipe';
+import Swipe, { SwipeProps as ReactEasySwipeProps } from 'react-easy-swipe';
 import Carousel from '../components/Carousel';
 import Thumbs from '../components/Thumbs';
 import getDocument from '../shims/document';

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -70,23 +70,19 @@ export default class Carousel extends React.Component<CarouselProps, CarouselSta
         renderItem: (item: React.ReactNode) => {
             return item;
         },
-        renderThumbs: (children: React.ReactChild[]) => {
-            const images = Children.map<React.ReactChild | undefined, React.ReactChild>(children, (item) => {
-                let img: React.ReactChild | undefined = item;
+        renderThumbs: (children: React.ReactNode) => {
+            const findFirstImage = (children: React.ReactNode) =>
+                Children.toArray(children)
+                    .filter(React.isValidElement)
+                    .find((child) => child.type === 'img');
 
-                // if the item is not an image, try to find the first image in the item's children.
-                if ((item as React.ReactElement<{ children: React.ReactChild[] }>).type !== 'img') {
-                    img = (Children.toArray((item as React.ReactElement).props.children) as React.ReactChild[]).find(
-                        (children) => (children as React.ReactElement).type === 'img'
-                    );
-                }
+            const images = Children.toArray(children)
+                .filter((item): item is React.ReactElement => React.isValidElement(item))
+                .map((item) => {
+                    const img = item.type === 'img' ? item : findFirstImage(item.props.children);
 
-                if (!img) {
-                    return undefined;
-                }
-
-                return img;
-            });
+                    return img ? img : undefined;
+                });
 
             if (images.filter((image) => image).length === 0) {
                 console.warn(
@@ -611,12 +607,12 @@ export default class Carousel extends React.Component<CarouselProps, CarouselSta
         return null;
     };
 
-    renderItems(isClone?: boolean) {
+    renderItems(isClone?: boolean): React.ReactElement[] {
         if (!this.props.children) {
             return [];
         }
 
-        return Children.map(this.props.children, (item, index) => {
+        return Children.toArray(this.props.children).map((item, index) => {
             const isSelected = index === this.state.selectedItem;
             const isPrevious = index === this.state.previousItem;
 

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,6 +1,5 @@
 import React, { Children } from 'react';
-// @ts-ignore
-import Swipe, { ReactEasySwipeProps } from 'react-easy-swipe';
+import Swipe, { SwipeEvent, SwipeProps as ReactEasySwipeProps } from 'react-easy-swipe';
 import klass from '../../cssClasses';
 import Thumbs from '../Thumbs';
 import getDocument from '../../shims/document';
@@ -430,14 +429,14 @@ export default class Carousel extends React.Component<CarouselProps, CarouselSta
         this.moveTo(index);
     };
 
-    onSwipeStart = (event: React.TouchEvent) => {
+    onSwipeStart: ReactEasySwipeProps['onSwipeStart'] = (event) => {
         this.setState({
             swiping: true,
         });
         this.props.onSwipeStart(event);
     };
 
-    onSwipeEnd = (event: React.TouchEvent) => {
+    onSwipeEnd: ReactEasySwipeProps['onSwipeEnd'] = (event) => {
         this.setState({
             swiping: false,
             cancelClick: false,
@@ -452,7 +451,7 @@ export default class Carousel extends React.Component<CarouselProps, CarouselSta
         }
     };
 
-    onSwipeMove = (delta: { x: number; y: number }, event: React.TouchEvent) => {
+    onSwipeMove = (delta: { x: number; y: number }, event: SwipeEvent) => {
         this.props.onSwipeMove(event);
 
         const animationHandlerResponse = this.props.swipeAnimationHandler(
@@ -722,7 +721,7 @@ export default class Carousel extends React.Component<CarouselProps, CarouselSta
         const firstClone = itemsClone.shift();
         const lastClone = itemsClone.pop();
 
-        let swiperProps: ReactEasySwipeProps = {
+        let swiperProps: Partial<ReactEasySwipeProps> = {
             className: klass.SLIDER(true, this.state.swiping),
             onSwipeMove: this.onSwipeMove,
             onSwipeStart: this.onSwipeStart,

--- a/src/components/Carousel/types.ts
+++ b/src/components/Carousel/types.ts
@@ -40,9 +40,9 @@ export interface CarouselProps {
     onClickItem: (index: number, item: React.ReactNode) => void;
     onClickThumb: (index: number, item: React.ReactNode) => void;
     onChange: (index: number, item: React.ReactNode) => void;
-    onSwipeStart: (event: React.TouchEvent) => void;
-    onSwipeEnd: (event: React.TouchEvent) => void;
-    onSwipeMove: (event: React.TouchEvent) => boolean;
+    onSwipeStart: (event: React.TouchEvent | React.MouseEvent) => void;
+    onSwipeEnd: (event: React.TouchEvent | React.MouseEvent) => void;
+    onSwipeMove: (event: React.TouchEvent | React.MouseEvent) => boolean;
     preventMovementUntilSwipeScrollTolerance: boolean;
     renderArrowPrev: (clickHandler: () => void, hasPrev: boolean, label: string) => React.ReactNode;
     renderArrowNext: (clickHandler: () => void, hasNext: boolean, label: string) => React.ReactNode;

--- a/src/components/Carousel/types.ts
+++ b/src/components/Carousel/types.ts
@@ -26,7 +26,7 @@ export interface CarouselProps {
     autoPlay?: boolean;
     centerMode?: boolean;
     centerSlidePercentage: number;
-    children?: React.ReactChild[];
+    children?: React.ReactNode;
     className?: string;
     dynamicHeight?: boolean;
     emulateTouch?: boolean;
@@ -53,7 +53,7 @@ export interface CarouselProps {
         label: string
     ) => React.ReactNode;
     renderItem: (item: React.ReactNode, options?: { isSelected: boolean; isPrevious: boolean }) => React.ReactNode;
-    renderThumbs: (children: React.ReactChild[]) => React.ReactChild[];
+    renderThumbs: (children: React.ReactNode) => React.ReactNode[];
     selectedItem: number;
     showArrows: boolean;
     showStatus: boolean;

--- a/src/components/Carousel/utils.ts
+++ b/src/components/Carousel/utils.ts
@@ -43,7 +43,6 @@ export const getPosition = (index: number, props: CarouselProps): number => {
 /**
  * Sets the 'position' transform for sliding animations
  * @param position
- * @param forceReflow
  */
 export const setPosition = (position: number, axis: 'horizontal' | 'vertical'): React.CSSProperties => {
     const cssTranslated = CSSTranslate(position, '%', axis);

--- a/src/components/Carousel/utils.ts
+++ b/src/components/Carousel/utils.ts
@@ -46,11 +46,14 @@ export const getPosition = (index: number, props: CarouselProps): number => {
  * @param forceReflow
  */
 export const setPosition = (position: number, axis: 'horizontal' | 'vertical'): React.CSSProperties => {
-    const style = {};
-    ['WebkitTransform', 'MozTransform', 'MsTransform', 'OTransform', 'transform', 'msTransform'].forEach((prop) => {
-        // @ts-ignore
-        style[prop] = CSSTranslate(position, '%', axis);
-    });
-
-    return style;
+    const cssTranslated = CSSTranslate(position, '%', axis);
+    return ['WebkitTransform', 'MozTransform', 'MsTransform', 'OTransform', 'transform', 'msTransform'].reduce<
+        React.CSSProperties
+    >(
+        (styles, prop) => ({
+            ...styles,
+            [prop]: cssTranslated,
+        }),
+        {}
+    );
 };

--- a/src/components/Thumbs.tsx
+++ b/src/components/Thumbs.tsx
@@ -2,7 +2,6 @@ import React, { Component, Children } from 'react';
 import klass from '../cssClasses';
 import { outerWidth } from '../dimensions';
 import CSSTranslate from '../CSSTranslate';
-// @ts-ignore
 import Swipe from 'react-easy-swipe';
 import getWindow from '../shims/window';
 

--- a/src/components/Thumbs.tsx
+++ b/src/components/Thumbs.tsx
@@ -11,7 +11,7 @@ const isKeyboardEvent = (e: React.MouseEvent | React.KeyboardEvent): e is React.
 
 export interface Props {
     axis: 'horizontal' | 'vertical';
-    children: React.ReactChild[];
+    children: React.ReactNode;
     labels: {
         leftArrow: string;
         rightArrow: string;

--- a/src/components/Thumbs.tsx
+++ b/src/components/Thumbs.tsx
@@ -240,15 +240,15 @@ export default class Thumbs extends Component<Props, State> {
     }
 
     renderItems() {
-        return this.props.children.map((img, index) => {
+        return React.Children.toArray(this.props.children).map((img, index) => {
             const itemClass = klass.ITEM(false, index === this.state.selectedItem);
 
             const thumbProps = {
                 key: index,
                 ref: (e: HTMLLIElement) => this.setThumbsRef(e, index),
                 className: itemClass,
-                onClick: this.handleClickItem.bind(this, index, this.props.children[index]),
-                onKeyDown: this.handleClickItem.bind(this, index, this.props.children[index]),
+                onClick: this.handleClickItem.bind(this, index, img),
+                onKeyDown: this.handleClickItem.bind(this, index, img),
                 'aria-label': `${this.props.labels.item} ${index + 1}`,
                 style: { width: this.props.thumbWidth },
             };


### PR DESCRIPTION
Closes #703

Children prop was typed with React.ReactChild which should be replaced with ReactNode to cover everything that React can accept as children (https://www.carlrippon.com/react-children-with-typescript/)

I also tried to remove all the related unsafe casts (`X as Y`) which led me to do some refactoring and rewriting, which should be for the better logically as it's now handling the cases that typescript detects. It could be worse performance wise though.

I also removed almost all @ts-ignore and fixed all errors previously ignored.



_I'm not sure if this will be merged given the project status and there's quite a few changes. I have not yet started using this project so I has not yet tested that everything works, been relying on the `yarn test` to assert correctness. But I felt like I might as well send the PR at least._